### PR TITLE
Dockerchanges

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -20,8 +20,6 @@ RUN pip install -r requirements.txt && pip install -r requirements-test.txt
 WORKDIR /crawler
 
 COPY . /crawler
-RUN pip install -r crawler/requirements.txt
-RUN pip install -r tests/requirements.txt
 
 CMD (docker daemon > ../docker.out 2>&1 &) && \
 	sleep 5 && \

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ build:
 	docker build -t crawler .
 
 test:
-	docker build -t test -f Dockerfile.test .
-	docker run --privileged -ti test
+	docker build -t agentless-system-crawler-test -f Dockerfile.test .
+	docker run --privileged -ti agentless-system-crawler-test

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ build:
 
 test:
 	docker build -t agentless-system-crawler-test -f Dockerfile.test .
-	docker run --privileged -ti agentless-system-crawler-test
+	docker run --privileged -ti --rm agentless-system-crawler-test


### PR DESCRIPTION

I feel we shouldn't use the tag "test" as if nothing in the world ever called itself that. In theory we should probably establish a repo and a name in the tag.

pip install was duplicated after a copy. I didn't originally intend to commit that change until later, but oh well. it should speed up the build because the pip installs should be cached, at least until you change requirements.

I also added a `--rm` to the test runner because we don't need to hang on to that container in general, and if eventually we need to get results out of it, we can mount a volume.

@duglin @ricarkol what you think?