### PR TITLE
codecov.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,20 @@ before_install:
 
     # upgrade docker-engine to specific version
     - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+    # might as well upgrade pip to support TLS and get rid of the warnings
+    - pip install --upgrade pip
+    - pip install codecov pytest-cov
 
 # command to install dependencies
 # TODO: having issues with the bottle package if we don't run sudo pip install.
 # It's mysterious and should be fixed eventually.
-install: "pip install -r requirements-test.txt; sudo pip install -r requirements-test.txt"
-
+install:
+  - pip install -r requirements-test.txt
+  - sudo pip install -r requirements-test.txt
+  
 # command to run tests
 script:
-- sudo `which py.test`
+  - sudo $( which py.test ) --cov=./
+
+after_success:
+  - codecov


### PR DESCRIPTION
example output, (without needing the plugin available at ) at https://codecov.io/gh/MHBauer/agentless-system-crawler

this would require some extra settings to configure the repo to add either badges or interactive support in github.