### PR TITLE
setup.py

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+### Python ### 
+**/__pycache__
+*.py[cod]
+build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 .vagrant/*
-*.pyc
+## python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+# distribution
+build/
+dist/
+eggs/
+.eggs/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   
 # command to run tests
 script:
-  - sudo $( which py.test ) --cov=./
+  - sudo python setup.py test --addopts '--cov=.'
 
 after_success:
   - flake8 --max-complexity 10 .

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -25,4 +25,4 @@ CMD (docker daemon > ../docker.out 2>&1 &) && \
 	sleep 5 && \
         flake8 --max-complexity 10 . || true && \
         pylint crawler || true && \
-	py.test 
+        python setup.py test --addopts '--cov=.'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@
 simplejson==3.8.2
 flake8==2.6.0
 pylint==1.5.6
+pytest-cov==2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+
+from setuptools import setup, find_packages
+
+setup(
+    name='agentless-system-crawler',
+    version='0.0.1.dev',
+    #description='',
+    #long_description=long_description,
+    author='IBM',
+    #author_email='',
+    license='apache2',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+    ],
+    packages = find_packages(),
+    install_requires=['psutil','netifaces',],
+    
+    setup_requires=['pytest-runner>=2.0,<3dev',],
+    tests_require=['pytest',],
+    use_2to3=True,
+)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 flake8==2.6.0
 pylint==1.5.6
+pytest-cov==2.2.1


### PR DESCRIPTION
 - some dockerignore entries for python caching
 - gitignore entries for python distribution
 - setup.py and stuff to use it

running `py.test` directly should still work and do the right thing.