### PR TITLE
crawler polling mechanism is changed to docker event subscription

### DIFF
--- a/crawler/containerevent.py
+++ b/crawler/containerevent.py
@@ -1,0 +1,24 @@
+"""
+container event object
+"""
+
+class ContainerEvent(object):
+        def __init__(self, cId, imgId, event, etime):
+                self.cId = cId
+                self.imgId = imgId
+                self.event = event
+                self.eventTime = etime
+
+        def get_containerid(self):
+                return self.cId
+
+        def get_imgageid(self):
+                return self.imgId
+
+        def get_event(self):
+                return self.event
+                      
+        def get_eventTime(self):
+                return eventTime
+
+

--- a/crawler/containerevent.py
+++ b/crawler/containerevent.py
@@ -3,22 +3,22 @@ container event object
 """
 
 class ContainerEvent(object):
-        def __init__(self, cId, imgId, event, etime):
-                self.cId = cId
-                self.imgId = imgId
-                self.event = event
-                self.eventTime = etime
+    def __init__(self, cId, imgId, event, etime):
+        self.cId = cId
+        self.imgId = imgId
+        self.event = event
+        self.eventTime = etime
 
-        def get_containerid(self):
-                return self.cId
+    def get_containerid(self):
+        return self.cId
 
-        def get_imgageid(self):
-                return self.imgId
+    def get_imgageid(self):
+        return self.imgId
 
-        def get_event(self):
-                return self.event
+    def get_event(self):
+        return self.event
                       
-        def get_eventTime(self):
-                return eventTime
+    def get_eventTime(self):
+        return eventTime
 
 

--- a/crawler/containers.py
+++ b/crawler/containers.py
@@ -132,3 +132,26 @@ def get_filtered_list_of_containers(
             filtered_list.append(container)
 
     return filtered_list
+
+def get_container(
+    options=defaults.DEFAULT_CRAWL_OPTIONS,
+    host_namespace=misc.get_host_ipaddr(),
+    containerId = None,
+):
+    environment = options.get('environment', defaults.DEFAULT_ENVIRONMENT)
+    metadata = options.get('metadata', {})
+    _map = metadata.get('container_long_id_to_namespace_map', {})
+    container_opts = {'host_namespace': host_namespace,
+                      'environment': environment,
+                      'long_id_to_namespace_map': _map,
+                      'container_logs': options['logcrawler']['default_log_files']
+                      }
+    user_list = containerId
+    container_list = list_all_containers(user_list, container_opts)
+    ret_container = None
+    for container in container_list:
+            ret_container = container
+            break
+
+    return ret_container
+    

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -28,6 +28,7 @@ import defaults
 import misc
 import crawlutils
 from crawlmodes import Modes
+from dockermonitor import DockerMonitor
 
 app = bottle.Bottle()
 
@@ -287,6 +288,14 @@ def crawler_worker(process_id, logfile, params):
 
     crawlutils.snapshot(**params)
 
+def docker_monitor(process_id, logfile, syncQ):
+    setup_logger('docker-monitor', logfile, process_id)
+    logger.info('*' * 50)
+    logger.info('Docker monitor #%d started.' % (process_id))
+    logger.info('*' * 50)
+
+    monitor = DockerMonitor(syncQ)
+    monitor.startMonitor()
 
 # (a) an autonomous push mode via command-line invocation
 
@@ -294,6 +303,8 @@ def start_autonomous_crawler(num_processes, logfile):
 
     if params['crawlmode'] == 'OUTCONTAINER':
         jobs = []
+	syncQ = multiprocessing.JoinableQueue()
+	delList = multiprocessing.Manager().list()
 
         for index in xrange(num_processes):
             # XXX use options.get() instead
@@ -301,6 +312,9 @@ def start_autonomous_crawler(num_processes, logfile):
             partition_args = options['partition_strategy']['args']
             partition_args['process_id'] = index
             partition_args['num_processes'] = num_processes
+	    partition_args['eventQ'] = syncQ
+	    partition_args['delList'] = delList
+
             p = multiprocessing.Process(
                 name='crawler-%s' %
                 index, target=crawler_worker, args=(
@@ -308,7 +322,16 @@ def start_autonomous_crawler(num_processes, logfile):
             jobs.append((p, index))
             p.start()
             logger.info('Crawler %s (pid=%s) started', index, p.pid)
+	
+	#now start docker event handler
+        eventProc = multiprocessing.Process(
+        	name='docker-monitor',
+        	target = docker_monitor, args=((index+1), logfile, syncQ))
 
+	#jobs.append((evntProc, (index+1)))
+        eventProc.start()
+        logging.info("docker container monitor started (pid=%s)", eventProc)
+	
         while jobs:
             for (index, (job, process_id)) in enumerate(jobs):
                 if not job.is_alive():
@@ -338,6 +361,10 @@ def start_autonomous_crawler(num_processes, logfile):
                             pid)
                     del jobs[index]
             time.sleep(0.1)
+	
+        logger.info('terminating docker-monitor process.(pid=%s)'%(eventProc.pid))
+	eventProc.terminate()
+
         logger.info('Exiting as there are no more processes running.')
     else:
 

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -303,8 +303,8 @@ def start_autonomous_crawler(num_processes, logfile):
 
     if params['crawlmode'] == 'OUTCONTAINER':
         jobs = []
-	syncQ = multiprocessing.JoinableQueue()
-	delList = multiprocessing.Manager().list()
+        syncQ = multiprocessing.JoinableQueue()
+        delList = multiprocessing.Manager().list()
 
         for index in xrange(num_processes):
             # XXX use options.get() instead
@@ -312,8 +312,8 @@ def start_autonomous_crawler(num_processes, logfile):
             partition_args = options['partition_strategy']['args']
             partition_args['process_id'] = index
             partition_args['num_processes'] = num_processes
-	    partition_args['eventQ'] = syncQ
-	    partition_args['delList'] = delList
+            partition_args['eventQ'] = syncQ
+            partition_args['delList'] = delList
 
             p = multiprocessing.Process(
                 name='crawler-%s' %
@@ -363,7 +363,7 @@ def start_autonomous_crawler(num_processes, logfile):
             time.sleep(0.1)
 	
         logger.info('terminating docker-monitor process.(pid=%s)'%(eventProc.pid))
-	eventProc.terminate()
+        eventProc.terminate()
 
         logger.info('Exiting as there are no more processes running.')
     else:

--- a/crawler/dockermonitor.py
+++ b/crawler/dockermonitor.py
@@ -4,24 +4,24 @@ import docker
 
 class DockerMonitor(object):
     def __init__(self, eventQ):
-        self.eventQ = eventQ
-        self.client = docker.Client(base_url='unix://var/run/docker.sock')
+         self.eventQ = eventQ
+         self.client = docker.Client(base_url='unix://var/run/docker.sock')
 
     def __container_start_handler(self, event):
-        containerid = event['id']
-        imageid = event['from']
-        epochtime = event['time']
-        cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
-        self.eventQ.put(cEvent)
-
-     def __container_delete_handler(self, event):
          containerid = event['id']
          imageid = event['from']
          epochtime = event['time']
          cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
          self.eventQ.put(cEvent)
 
-     def startMonitor(self):
+    def __container_delete_handler(self, event):
+         containerid = event['id']
+         imageid = event['from']
+         epochtime = event['time']
+         cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
+         self.eventQ.put(cEvent)
+
+    def startMonitor(self):
          events = self.client.events(decode=True)
          for event in events:
              if event['Action'] == 'start':

--- a/crawler/dockermonitor.py
+++ b/crawler/dockermonitor.py
@@ -1,0 +1,43 @@
+import sys
+from containerevent import ContainerEvent
+import docker
+
+class DockerMonitor(object):
+        def __init__(self, eventQ):
+                self.eventQ = eventQ
+		self.client = docker.Client(base_url='unix://var/run/docker.sock')
+
+        def __container_create_handler(self, event):
+                print "Container created"
+                print event
+
+        def __container_start_handler(self, event):
+                containerid = event['id']
+                imageid = event['from']
+                epochtime = event['time']
+                cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
+                self.eventQ.put(cEvent)
+
+        def __container_stop_handler(self, event):
+                print "Container stopped"
+                print event
+
+        def __container_delete_handler(self, event):
+                containerid = event['id']
+                imageid = event['from']
+                epochtime = event['time']
+                cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
+                self.eventQ.put(cEvent)
+
+        def startMonitor(self):
+		events = self.client.events(decode=True)
+                for event in events:
+                        if event['Action'] == 'start':
+                                self.__container_start_handler(event)
+                        if event['Action'] == 'stop':
+                                self.__container_stop_handler(event)
+                        if event['Action'] == 'created':
+                                self.__container_create_handler(event)
+                        if event['Action'] == 'die':
+                                self.__container_delete_handler(event)		
+

--- a/crawler/dockermonitor.py
+++ b/crawler/dockermonitor.py
@@ -3,41 +3,29 @@ from containerevent import ContainerEvent
 import docker
 
 class DockerMonitor(object):
-        def __init__(self, eventQ):
-                self.eventQ = eventQ
-		self.client = docker.Client(base_url='unix://var/run/docker.sock')
+    def __init__(self, eventQ):
+        self.eventQ = eventQ
+        self.client = docker.Client(base_url='unix://var/run/docker.sock')
 
-        def __container_create_handler(self, event):
-                print "Container created"
-                print event
+    def __container_start_handler(self, event):
+        containerid = event['id']
+        imageid = event['from']
+        epochtime = event['time']
+        cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
+        self.eventQ.put(cEvent)
 
-        def __container_start_handler(self, event):
-                containerid = event['id']
-                imageid = event['from']
-                epochtime = event['time']
-                cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
-                self.eventQ.put(cEvent)
+     def __container_delete_handler(self, event):
+         containerid = event['id']
+         imageid = event['from']
+         epochtime = event['time']
+         cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
+         self.eventQ.put(cEvent)
 
-        def __container_stop_handler(self, event):
-                print "Container stopped"
-                print event
-
-        def __container_delete_handler(self, event):
-                containerid = event['id']
-                imageid = event['from']
-                epochtime = event['time']
-                cEvent = ContainerEvent(containerid, imageid, event['Action'], epochtime)
-                self.eventQ.put(cEvent)
-
-        def startMonitor(self):
-		events = self.client.events(decode=True)
-                for event in events:
-                        if event['Action'] == 'start':
-                                self.__container_start_handler(event)
-                        if event['Action'] == 'stop':
-                                self.__container_stop_handler(event)
-                        if event['Action'] == 'created':
-                                self.__container_create_handler(event)
-                        if event['Action'] == 'die':
-                                self.__container_delete_handler(event)		
+     def startMonitor(self):
+         events = self.client.events(decode=True)
+         for event in events:
+             if event['Action'] == 'start':
+                 self.__container_start_handler(event)
+             if event['Action'] == 'die':
+                 self.__container_delete_handler(event)		
 

--- a/tests/test_crawler_container.py
+++ b/tests/test_crawler_container.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import subprocess
+import multiprocessing
 
 # Tests for crawlers in kraken crawlers configuration.
 
@@ -96,7 +97,9 @@ class SingleContainerTests(unittest.TestCase):
 		'partition_strategy': {
 		    'args': {
 			'process_id': 0,
-			'num_processes': 1
+			'num_processes': 1,
+			'eventQ':multiprocessing.JoinableQueue(),
+			'delList':multiprocessing.Manager().list()
 		    },
 		    'name': 'equally_by_pid'
 		},

--- a/tests/test_dockerevent_crawler.py
+++ b/tests/test_dockerevent_crawler.py
@@ -1,0 +1,146 @@
+import unittest
+import docker
+import requests.exceptions
+import tempfile
+import os
+import shutil
+import subprocess
+import commands
+import time
+import multiprocessing
+# Tests conducted with a single container running.
+
+class CrawlerDockerEventTests(unittest.TestCase):
+
+    def setUp(self):
+        self.docker = docker.Client(
+            base_url='unix://var/run/docker.sock', version='auto')
+        try:
+            if len(self.docker.containers()) != 0:
+                raise Exception(
+                    "Sorry, this test requires a machine with no docker containers running.")
+        except requests.exceptions.ConnectionError as e:
+            print "Error connecting to docker daemon, are you in the docker group? You need to be in the docker group."
+
+        self.docker.pull(repository='alpine', tag='latest')
+        self.tempd = tempfile.mkdtemp(prefix='crawlertest-events.')
+
+    def tearDown(self):
+	containers = self.docker.containers()
+	for container in containers:
+            self.docker.stop(container=container['Id'])
+            self.docker.remove_container(container=container['Id'])
+
+        #shutil.rmtree(self.tempd)
+
+    def __exec_crawler(self, cmd):
+	status, output = commands.getstatusoutput(cmd)
+	assert status == 0
+
+    def __exec_create_container(self):
+        container = self.docker.create_container(
+            image='alpine:latest', command='/bin/sleep 60')
+        self.docker.start(container=container['Id'])
+	return container['Id']
+
+    def __exec_delet_container(self, containerId):
+        self.docker.stop(container=containerId)
+        self.docker.remove_container(container=containerId)
+
+    '''
+    This is a basic sanity test. It first creates a container and then starts crawler.
+    In this case, crawler would miss the create event, but it should be able to
+    discover already running containers and snapshot them
+    '''
+    def testCrawlContainer0(self):
+        env = os.environ.copy()
+        mypath = os.path.dirname(os.path.realpath(__file__))
+        os.makedirs(self.tempd + '/out')
+
+	self.__exec_create_container()
+
+        # crawler itself needs to be root
+        process = subprocess.Popen(
+            [
+                '/usr/bin/python', mypath + '/../crawler/crawler.py',
+                '--url', 'file://' + self.tempd + '/out/crawler',
+                '--features', 'cpu,memory,interface',
+                '--crawlContainers', 'ALL',
+                '--format', 'graphite',
+                '--crawlmode', 'OUTCONTAINER',
+                '--numprocesses', '1'
+            ],
+            env=env)
+        stdout, stderr = process.communicate()
+        assert process.returncode == 0
+
+        subprocess.call(['/bin/chmod', '-R', '777', self.tempd])
+
+        files = os.listdir(self.tempd + '/out')
+        assert len(files) == 1
+
+        f = open(self.tempd + '/out/' + files[0], 'r')
+        output = f.read()
+        assert 'interface-lo.if_octets.tx' in output
+        assert 'cpu-0.cpu-idle' in output
+        assert 'memory.memory-used' in output
+        f.close()
+
+	#clear the outut direcory
+	shutil.rmtree(os.path.join(self.tempd, 'out')) 
+  	
+    '''
+    In this test, crawler is started with high snapshot frequency (60 sec),
+    and container is created immediately. Expected behaviour is that
+    crawler should get intrupptted and start snapshotting container immediately.
+
+    And then we will wait for crawler's next iteration to ensure, w/o docker event,
+    crawler will timeout and snapshot container periodically
+    '''
+    def testCrawlContainer1(self):
+        env = os.environ.copy()
+        mypath = os.path.dirname(os.path.realpath(__file__))
+        os.makedirs(self.tempd + '/out')
+        
+	# crawler itself needs to be root
+	cmd = ''.join([
+                '/usr/bin/python ', mypath + '/../crawler/crawler.py ',
+                '--url ', 'file://' + self.tempd + '/out/crawler ',
+                '--features ', 'cpu,memory,interface ',
+                '--crawlContainers ', 'ALL ',
+                '--format ', 'graphite ',
+                '--crawlmode ', 'OUTCONTAINER ',
+                '--numprocesses ', '4 '
+            ])
+	crawlerProc = multiprocessing.Process(
+			name='crawler', target=self.__exec_crawler,
+			args=(cmd,))
+	
+	createContainerProc = multiprocessing.Process(
+                        name='createContainer', target=self.__exec_create_container
+                )
+
+	crawlerProc.start()
+	createContainerProc.start()
+
+	while True:
+		if crawlerProc.is_alive():
+			time.sleep(0.1)
+		else:
+			break		
+	
+        subprocess.call(['/bin/chmod', '-R', '777', self.tempd])
+
+        files = os.listdir(self.tempd + '/out')
+        assert len(files) == 1
+
+        f = open(self.tempd + '/out/' + files[0], 'r')
+        output = f.read()
+        #print output  # only printed if the test fails
+        assert 'interface-lo.if_octets.tx' in output
+        assert 'cpu-0.cpu-idle' in output
+        assert 'memory.memory-used' in output
+        f.close()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ref. Issue #51
# Problem:

In the current system, crawler polls periodically to discover if any new container is created or existing container is deleted. If some container is created and deleted in-between this polling period, it would not be able to snapshot that container.
# Propose Solution:

make crawler event-driven or more precisely interruptible. Register for docker events (externally in docker client) and when a new container is created, it gets interrupted and snapshot them immediately.
