### PR TITLE
links log files in mounted volumes

### DIFF
--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -350,28 +350,28 @@ class DockerContainer(Container):
                 if name.startswith(mount['Destination']):
                     lname = name.replace(mount['Destination'], mount['Source'])
                     if "*" in lname:
-                        src_dest = [(s, s.replace(mount['Source'],\
-                             mount['Destination'])) for s in glob.glob(lname)]
+                        src_dest = [(s, s.replace(mount['Source'], mount[
+                                     'Destination'])) for s in glob.glob(lname)]
                     else:
                         src_dest = [(lname, name)]
                 else:
                     lname = rootfs_path + name
                     if "*" in lname:
-                        src_dest = [(s, s.split(rootfs_path, 1)[1]) \
-                            for s in glob.glob(lname)]
+                        src_dest = [(s, s.split(rootfs_path, 1)[1])
+                                    for s in glob.glob(lname)]
                     else:
                         src_dest = [(lname, name)]
 
             for log_src, log_dest in src_dest:
-               log_dest = host_log_dir + log_dest
-               log = {
-                  'name': name,
-                  'type': _type,
-                  'source': log_src,
-                  'dest': log_dest}
+                log_dest = host_log_dir + log_dest
+                log = {
+                    'name': name,
+                    'type': _type,
+                    'source': log_src,
+                    'dest': log_dest}
 
-               if log not in logs_list:
-                  logs_list.append(log)
+                if log not in logs_list:
+                    logs_list.append(log)
 
         logger.info('logmap %s' % logs_list)
 

--- a/tests/test_logs_in_volumes1.py
+++ b/tests/test_logs_in_volumes1.py
@@ -1,0 +1,85 @@
+import unittest
+import tempfile
+import os
+import shutil
+
+from crawler import dockerutils 
+from crawler import dockercontainer
+
+# Tests dockercontainer._get_logfiles_list
+# the log file, test1.log is in a host directory
+# mounted as volume
+
+def get_docker_container_rootfs_path(long_id, inspect):
+    return "rootfs"
+
+def get_container_log_files(path, options):
+    pass
+
+class DockerContainerTests(unittest.TestCase):
+
+    def setUp(self):
+
+        self.host_log_dir = tempfile.mkdtemp(prefix='host_log_dir.')
+        self.volume = tempfile.mkdtemp(prefix='volume.')
+        for logf in ['test1.log', 'test2.log']:
+            with open(os.path.join(self.volume, logf), 'w') as logp:
+                logp.write(logf)
+
+        self.inspect = \
+        {
+            "Id": "1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847",
+            "Created": "2016-07-06T16:38:05.479090842Z",
+            "State": {
+                "Status": "running",
+                "Running": True,
+                "Pid": 11186
+            },
+            "Image": "sha256:07c86167cdc4264926fa5d2894e34a339ad27f730e8cc81a16cd21b7479e8eac",
+            "Name": "/pensive_rosalind",
+            "LogPath": "/var/lib/docker/containers/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847-json.log",
+            "HostnamePath": "/var/lib/docker/containers/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847/hostname",
+            "Mounts": [
+                {
+                    "Source": self.volume,
+                    "Destination": "/data"
+                }
+            ],
+            "Config": {
+                "Cmd": [
+                    "bash"
+                ],
+                "Image": "ubuntu:trusty"
+            },
+            "docker_image_long_name": "long_name/short_name",
+            "docker_image_short_name": "short_name",
+            "docker_image_tag": "image_tag",
+            "docker_image_registry": "image_registry",
+            "owner_namespace": "owner_namespace",
+            "NetworkSettings": {
+            }
+        }
+        self.docker_container = dockercontainer.\
+                    DockerContainer(self.inspect['Id'], self.inspect)
+
+        dockerutils.get_docker_container_rootfs_path = \
+            get_docker_container_rootfs_path
+
+        self.docker_container._get_container_log_files = get_container_log_files
+        self.docker_container.log_file_list = [{'name': '/data/test1.log', 'type': None}]
+   
+    def tearDown(self):
+        shutil.rmtree(self.volume)
+        shutil.rmtree(self.host_log_dir)
+
+    def test_get_logfiles_list(self):
+        log_list = self.docker_container._get_logfiles_list(self.host_log_dir, {})
+        for log_dict in log_list:
+            if log_dict['name'] == '/data/test1.log':
+                self.assertEqual(log_dict['dest'], self.host_log_dir + '/data/test1.log')
+                self.assertEqual(log_dict['source'], self.volume + '/test1.log')
+
+if __name__ == '__main__':
+        logging.basicConfig(filename='test_dockerutils.log', filemode='a', format='%(asctime)s %(levelname)s : %(message)s', level=logging.DEBUG)
+
+        unittest.main()

--- a/tests/test_logs_in_volumes_star.py
+++ b/tests/test_logs_in_volumes_star.py
@@ -1,0 +1,86 @@
+import unittest
+import tempfile
+import os
+import shutil
+
+from crawler import dockerutils 
+from crawler import dockercontainer
+
+# Tests dockercontainer._get_logfiles_list
+# the log file, test1.log is in a host directory
+# mounted as volume
+
+def get_docker_container_rootfs_path(long_id, inspect):
+    return "rootfs"
+
+def get_container_log_files(path, options):
+    pass
+
+class DockerContainerTests(unittest.TestCase):
+
+    def setUp(self):
+
+        self.host_log_dir = tempfile.mkdtemp(prefix='host_log_dir.')
+        self.volume = tempfile.mkdtemp(prefix='volume.')
+        self.log_file_list =  ['test1.log', 'test2.log']
+        for logf in self.log_file_list:
+            with open(os.path.join(self.volume, logf), 'w') as logp:
+                logp.write(logf)
+
+        self.inspect = \
+        {
+            "Id": "1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847",
+            "Created": "2016-07-06T16:38:05.479090842Z",
+            "State": {
+                "Status": "running",
+                "Running": True,
+                "Pid": 11186
+            },
+            "Image": "sha256:07c86167cdc4264926fa5d2894e34a339ad27f730e8cc81a16cd21b7479e8eac",
+            "Name": "/pensive_rosalind",
+            "LogPath": "/var/lib/docker/containers/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847-json.log",
+            "HostnamePath": "/var/lib/docker/containers/1e744b5e3e11e848863fefe9d9a8b3731070c6b0c702a04d2b8ab948ea24e847/hostname",
+            "Mounts": [
+                {
+                    "Source": self.volume,
+                    "Destination": "/data"
+                }
+            ],
+            "Config": {
+                "Cmd": [
+                    "bash"
+                ],
+                "Image": "ubuntu:trusty"
+            },
+            "docker_image_long_name": "long_name/short_name",
+            "docker_image_short_name": "short_name",
+            "docker_image_tag": "image_tag",
+            "docker_image_registry": "image_registry",
+            "owner_namespace": "owner_namespace",
+            "NetworkSettings": {
+            }
+        }
+        self.docker_container = dockercontainer.\
+                    DockerContainer(self.inspect['Id'], self.inspect)
+
+        dockerutils.get_docker_container_rootfs_path = \
+            get_docker_container_rootfs_path
+
+        self.docker_container._get_container_log_files = get_container_log_files
+        self.docker_container.log_file_list = [{'name': '/data/test*.log', 'type': None}]
+   
+    def tearDown(self):
+        shutil.rmtree(self.volume)
+        shutil.rmtree(self.host_log_dir)
+
+    def test_get_logfiles_list(self):
+        log_list = self.docker_container._get_logfiles_list(self.host_log_dir, {})
+        for log_dict in log_list:
+            if log_dict['name'] == '/data/test*.log':
+                assert os.path.basename(log_dict['dest']) in self.log_file_list
+                assert os.path.basename(log_dict['source']) in self.log_file_list
+
+if __name__ == '__main__':
+        logging.basicConfig(filename='test_dockerutils.log', filemode='a', format='%(asctime)s %(levelname)s : %(message)s', level=logging.DEBUG)
+
+        unittest.main()


### PR DESCRIPTION
Ricardo please merge these changes.

With these changes crawler could create proper links for log files in mounted docker volumes

I also added to test cases.

The above change is not tested with log files in docker volumes. In other words, the changes are tested only with host directories mounted as docker volumes. 