### PR TITLE
flake8 --count --exit-zero --max-complexity=10 --statistics .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ script:
   - sudo python setup.py test --addopts '--cov=.'
 
 after_success:
-  # 79 chars per line was OK for punch cards!  127 chars is the width of GitHub code viewer / editor.
-  - flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics .
+  - flake8 --count --exit-zero --max-complexity=10 --statistics .
   - pylint crawler
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
   - sudo python setup.py test --addopts '--cov=.'
 
 after_success:
-  - flake8 --max-complexity 10 .
+  # 79 chars per line was OK for punch cards!  127 chars is the width of GitHub code viewer / editor.
+  - flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics .
   - pylint crawler
   - codecov


### PR DESCRIPTION
79 chars per line was OK for punch cards!  127 chars is the width of GitHub code viewer / editor.

Signed-off-by: Christian Clauss <cclauss@bluewin.ch>