### PR TITLE
Adding a coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source = crawler
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*


### PR DESCRIPTION
This is not count the tests python files as part of the coverage calculations.

Signed-off-by: Ricardo Koller <kollerr@us.ibm.com>