### PR TITLE
cleanup whitespace errors and enforce their absence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
 
 install:
   - sudo -H pip install --ignore-installed -r requirements-test.txt
+  - echo "fix whitespace errors with 'autopep8 --select E1 --recursive --in-place .'" && flake8  --select E1
 
 # command to run tests
 script:

--- a/crawler/emitter.py
+++ b/crawler/emitter.py
@@ -323,15 +323,15 @@ class Emitter:
             except OSError:
                 #queue.close() # closing queue in finally clause
                 raise
-    
+
             try:
                 (result, child_exception) = queue.get(
                     timeout=self.kafka_timeout_secs)
             except Queue.Empty:
                 child_exception = EmitterEmitTimeout()
-    
+
             child_process.join(self.kafka_timeout_secs)
-    
+
             if child_process.is_alive():
                 errmsg = ('Timed out waiting for process %d to exit.' %
                           child_process.pid)
@@ -339,7 +339,7 @@ class Emitter:
                 os.kill(child_process.pid, 9)
                 logger.error(errmsg)
                 raise EmitterEmitTimeout(errmsg)
-    
+
             if child_exception:
                 raise child_exception
         finally:

--- a/tests/unit/test_crawlutils.py
+++ b/tests/unit/test_crawlutils.py
@@ -50,7 +50,7 @@ class MockedFeaturesCrawler:
 
     def __init__(self, *args, **kwargs):
         self.funcdict = {
-          'os': self.crawl_os
+            'os': self.crawl_os
         }
 
     def crawl_os(self, *args, **kwargs):
@@ -60,7 +60,7 @@ class MockedFeaturesCrawlerFailure:
 
     def __init__(self, *args, **kwargs):
         self.funcdict = {
-          'os': self.crawl_os
+            'os': self.crawl_os
         }
 
     def crawl_os(self, *args, **kwargs):
@@ -137,10 +137,10 @@ class ContainerTests(unittest.TestCase):
                 side_effect=MockedEmitter, autospec=True)
     def test_snapshot_mesos(self, *args):
         snapshot_mesos(snapshot_num=123,
-                           features='frame',
-                           urls=['stdout://', 'file:///tmp/frame',
-                                 'kafka://ip:123/topic'],
-                           ignore_exceptions=False)
+                       features='frame',
+                       urls=['stdout://', 'file:///tmp/frame',
+                             'kafka://ip:123/topic'],
+                       ignore_exceptions=False)
         # MockedEmitter is doing all the checks
 
 
@@ -151,7 +151,7 @@ class ContainerTests(unittest.TestCase):
     def test_snapshot_mesos(self, *args):
         with self.assertRaises(OSError):
             snapshot_mesos(snapshot_num=123,
-                               features='frame',
-                               urls=['stdout://', 'file:///tmp/frame',
-                                     'kafka://ip:123/topic'],
-                               ignore_exceptions=False)
+                           features='frame',
+                           urls=['stdout://', 'file:///tmp/frame',
+                                 'kafka://ip:123/topic'],
+                           ignore_exceptions=False)

--- a/tests/unit/test_emitter.py
+++ b/tests/unit/test_emitter.py
@@ -281,13 +281,13 @@ class EmitterTests(unittest.TestCase):
         emitter.__enter__()
         with self.assertRaises(ValueError):
             emitter.__exit__(None, ValueError('a'), None)
-        
+
         with self.assertRaises(ValueError):
             with Emitter(urls=['file:///tmp/test_emitter'],
-                              emitter_args={'extra': '{"a2}',
-                                        'extra_all_features': True,
-                                        'uuid': 'aaaaaa'},
-                              format='csv') as emitter:
+                         emitter_args={'extra': '{"a2}',
+                                       'extra_all_features': True,
+                                       'uuid': 'aaaaaa'},
+                         format='csv') as emitter:
                 raise ValueError('bla')
 
     def test_emitter_incorrect_json(self):

--- a/tests/unit/test_features_crawler.py
+++ b/tests/unit/test_features_crawler.py
@@ -408,21 +408,21 @@ class FeaturesCrawlerTests(unittest.TestCase):
             fc = FeaturesCrawler(crawl_mode=Modes.OUTVM)
 
     @mock.patch('crawler.features_crawler.psvmi.context_init',
-                 side_effect=lambda dn1, dn2, kv, d, a: 1000)
+                side_effect=lambda dn1, dn2, kv, d, a: 1000)
 
     @mock.patch('crawler.features_crawler.psvmi.system_info',
                 side_effect=lambda vmc: psvmi_sysinfo(1000,
-                                                       '1.1.1.1',
-                                                       'osdistro',
-                                                       'osname',
-                                                       'osplatform',
-                                                       'osrelease',
-                                                       'ostype',
-                                                       'osversion',
-                                                       1000000,
-                                                       100000,
-                                                       100000,
-                                                       100000))
+                                                      '1.1.1.1',
+                                                      'osdistro',
+                                                      'osname',
+                                                      'osplatform',
+                                                      'osrelease',
+                                                      'ostype',
+                                                      'osversion',
+                                                      1000000,
+                                                      100000,
+                                                      100000,
+                                                      100000))
     def _test_crawl_os_outvm_mode_without_vm(self, *args):
         fc = FeaturesCrawler(crawl_mode=Modes.OUTVM,
                              vm=('dn', '2.6', 'ubuntu', 'x86'))
@@ -1156,13 +1156,13 @@ class FeaturesCrawlerTests(unittest.TestCase):
             for (k, f) in fc.crawl_memory():
                 pass
         assert args[0].call_count == 1
-    
+
     @mock.patch('crawler.features_crawler.psvmi.context_init',
-                 side_effect=lambda dn1, dn2, kv, d, a: 1000)
+                side_effect=lambda dn1, dn2, kv, d, a: 1000)
 
     @mock.patch('crawler.features_crawler.psvmi.system_memory_info',
                 side_effect=lambda vmc: psvmi_memory(10, 20, 30, 40))
-    
+
     def _test_crawl_memory_outvm_mode(self, *args):
         fc = FeaturesCrawler(crawl_mode=Modes.OUTVM,
                              vm=('dn', '2.6', 'ubuntu', 'x86'))

--- a/tests/unit/test_osinfo.py
+++ b/tests/unit/test_osinfo.py
@@ -2,14 +2,14 @@ from unittest import TestCase
 import unittest
 import mock
 from crawler.osinfo import (_get_file_name,
-                    parse_lsb_release, 
-                    parse_os_release, 
-                    parse_redhat_release, 
-                    parse_centos_release,
-                    get_osinfo_from_lsb_release,
-                    get_osinfo_from_os_release,
-                    get_osinfo_from_redhat_centos
-                    )
+                            parse_lsb_release, 
+                            parse_os_release, 
+                            parse_redhat_release, 
+                            parse_centos_release,
+                            get_osinfo_from_lsb_release,
+                            get_osinfo_from_os_release,
+                            get_osinfo_from_redhat_centos
+                            )
 
 class Test_osinfo(TestCase):
 
@@ -32,19 +32,19 @@ class Test_osinfo(TestCase):
                  'HOME_URL="http://www.ubuntu.com/"',
                  'SUPPORT_URL="http://help.ubuntu.com/"',
                  'BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"'
-                ]
+                 ]
         result = parse_os_release(data)
         self.assertEqual(result['os'], 'ubuntu')
         self.assertEqual(result['version'], '14.04')
 
     def test_alpine_parse_os_release(self):
         data = [ 'NAME="Alpine Linux"',
-                'ID=alpine',
-                'VERSION_ID=3.4.0',
-                'PRETTY_NAME="Alpine Linux v3.4"',
-                'HOME_URL="http://alpinelinux.org"',
-                'BUG_REPORT_URL="http://bugs.alpinelinux.org"'
-               ]
+                 'ID=alpine',
+                 'VERSION_ID=3.4.0',
+                 'PRETTY_NAME="Alpine Linux v3.4"',
+                 'HOME_URL="http://alpinelinux.org"',
+                 'BUG_REPORT_URL="http://bugs.alpinelinux.org"'
+                 ]
 
         result = parse_os_release(data)
         self.assertEqual(result['os'], 'alpine')
@@ -110,7 +110,7 @@ class Test_osinfo(TestCase):
                  'HOME_URL="http://www.ubuntu.com/"',
                  'SUPPORT_URL="http://help.ubuntu.com/"',
                  'BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"'
-                ]
+                 ]
         with mock.patch('__builtin__.open', mock.mock_open(read_data="\n".join(data)), \
                         create=True) as m:
             m.return_value.__iter__.return_value = data


### PR DESCRIPTION
Whitespace rules are classified under `E1`. Going forward we can either `--select` more rules or move checkers off into a script.