### PR TITLE
crawler does not die on EmitterTimeoutException

### DIFF
--- a/crawler/emitter.py
+++ b/crawler/emitter.py
@@ -424,7 +424,10 @@ class Emitter:
         try:
             self._close_file()
             for url in self.urls:
-                self._publish(url)
+                try:
+                    self._publish(url)
+                except EmitterEmitTimeout as exc:
+                    logger.warning("Failed to emit due to timout, continuing anyway...")
         finally:
             if os.path.exists(self.temp_fpath):
                 os.remove(self.temp_fpath)

--- a/tests/unit/test_emitter.py
+++ b/tests/unit/test_emitter.py
@@ -681,12 +681,12 @@ class EmitterTests(unittest.TestCase):
         metadata = {}
         metadata['namespace'] = 'namespace777'
         retries = 2
-        with self.assertRaises(crawler.crawler_exceptions.EmitterEmitTimeout):
-            with Emitter(urls=['kafka://1.1.1.1:123/timeouttopic'],
-                         emitter_args=metadata,
-                         max_emit_retries=retries,
-                         kafka_timeout_secs=0.1) as emitter:
-                emitter.emit("dummy", {'test': 'bla'}, 'dummy')
+        #with self.assertRaises(crawler.crawler_exceptions.EmitterEmitTimeout):
+        with Emitter(urls=['kafka://1.1.1.1:123/timeouttopic'],
+                     emitter_args=metadata,
+                     max_emit_retries=retries,
+                     kafka_timeout_secs=0.1) as emitter:
+            emitter.emit("dummy", {'test': 'bla'}, 'dummy')
 
     @mock.patch(
         'crawler.emitter.multiprocessing.Process',


### PR DESCRIPTION
Signed-off-by: Sastry Duri <sastry@us.ibm.com>