### PR TITLE
Moving the os container crawl function to a plugin

### DIFF
--- a/crawler/features_crawler.py
+++ b/crawler/features_crawler.py
@@ -79,7 +79,7 @@ class FeaturesCrawler:
         self.vm_context = vm_context
 
         self.funcdict = {
-            'os': self.crawl_os,
+            #'os': self.crawl_os,
             'disk': self.crawl_disk_partitions,
             'metric': self.crawl_metrics,
             'process': self.crawl_processes,

--- a/crawler/icrawl_plugin.py
+++ b/crawler/icrawl_plugin.py
@@ -1,0 +1,24 @@
+from yapsy.IPlugin import IPlugin
+
+
+class IContainerCrawler(IPlugin):
+
+    """
+    Crawler plugin interface
+
+    Subclasses of this class can be used to implement crawling functions
+    for different systems.
+    """
+    def crawl(self, container_id):
+        """
+        Crawling function that should return a list of features for
+        `container_id`. This function is called once for every container
+        at every crawling interval.
+        """
+        raise NotImplementedError()
+
+    def get_feature(self):
+        """
+        Returns the feature type as a string.
+        """        
+        raise NotImplementedError()

--- a/crawler/plugins/os_container_crawler.plugin
+++ b/crawler/plugins/os_container_crawler.plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = OS crawling function for containers
+Module = os_container_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = OS crawling function for containers

--- a/crawler/plugins/os_container_crawler.py
+++ b/crawler/plugins/os_container_crawler.py
@@ -1,20 +1,18 @@
 import platform
-import dockerutils
-
-# Additional modules
-
+import misc
+import time
 import osinfo
+import dockerutils
+from icrawl_plugin import IContainerCrawler
+from features import OSFeature
+from namespace import run_as_another_namespace, ALL_NAMESPACES
+import logging
 
 # External dependencies that must be pip install'ed separately
 
 import psutil
-import misc
-import time
 
-
-from icrawl_plugin import IContainerCrawler
-from features import OSFeature
-from namespace import run_as_another_namespace, ALL_NAMESPACES
+logger = logging.getLogger('crawlutils')
 
 
 class OSContainerCrawler(IContainerCrawler):
@@ -26,6 +24,7 @@ class OSContainerCrawler(IContainerCrawler):
         inspect = dockerutils.exec_dockerinspect(container_id)
         state = inspect['State']
         pid = str(state['Pid'])
+        logger.debug('Crawling OS for container %s' % container_id)
         return run_as_another_namespace(pid,
                                         ALL_NAMESPACES,
                                         self._crawl_in_system)

--- a/crawler/plugins/os_container_crawler.py
+++ b/crawler/plugins/os_container_crawler.py
@@ -1,0 +1,90 @@
+import platform
+import dockerutils
+
+# Additional modules
+
+import osinfo
+
+# External dependencies that must be pip install'ed separately
+
+import psutil
+import misc
+import time
+
+
+from icrawl_plugin import IContainerCrawler
+from features import OSFeature
+from namespace import run_as_another_namespace, ALL_NAMESPACES
+
+
+class OSContainerCrawler(IContainerCrawler):
+
+    def get_feature(self):
+        return 'os'
+
+    def crawl(self, container_id):
+        inspect = dockerutils.exec_dockerinspect(container_id)
+        state = inspect['State']
+        pid = str(state['Pid'])
+        return run_as_another_namespace(pid,
+                                        ALL_NAMESPACES,
+                                        self._crawl_in_system)
+
+        # XXX consider moving this mode of crawling (without setns) to another
+        # plugin.
+        # return _crawl_without_setns(container_id)
+
+    def _crawl_in_system(self):
+        feature_key = platform.system().lower()
+        try:
+            os_kernel = platform.platform()
+        except:
+            os_kernel = 'unknown'
+
+        result = osinfo.get_osinfo(mount_point='/')
+        if result:
+            os_distro = result['os']
+            os_version = result['version']
+        else:
+            os_distro = 'unknown'
+            os_version = 'unknown'
+
+        ips = misc.get_host_ip4_addresses()
+
+        boot_time = psutil.boot_time()
+        uptime = int(time.time()) - boot_time
+        feature_attributes = OSFeature(
+            boot_time,
+            uptime,
+            ips,
+            os_distro,
+            os_version,
+            os_kernel,
+            platform.machine()
+        )
+
+        return [(feature_key, feature_attributes, 'os')]
+
+    def _crawl_without_setns(self, container_id):
+        mountpoint = dockerutils.get_docker_container_rootfs_path(container_id)
+
+        result = osinfo.get_osinfo(mount_point=mountpoint)
+        if result:
+            os_distro = result['os']
+            os_version = result['version']
+        else:
+            os_distro = 'unknown'
+            os_version = 'unknown'
+
+        feature_key = 'linux'
+        feature_attributes = OSFeature(  # boot time unknown for img
+                                         # live IP unknown for img
+            'unsupported',
+            'unsupported',
+            '0.0.0.0',
+            os_distro,
+            os_version,
+            'unknown',
+            'unknown'
+        )
+        return [(feature_key, feature_attributes, 'os')]

--- a/crawler/plugins_manager.py
+++ b/crawler/plugins_manager.py
@@ -1,11 +1,18 @@
 from yapsy.PluginManager import PluginManager
 from crawler_exceptions import RuntimeEnvironmentPluginNotFound
 from runtime_environment import IRuntimeEnvironment
+from icrawl_plugin import IContainerCrawler
 import misc
 
+# default runtime environment: cloudsigth and plugins in 'plugins/'
+runtime_env = None
 
-def load_env_plugin(plugin_places=[misc.execution_path('plugins')],
-                    environment='cloudsight'):
+container_crawl_plugins = []
+
+
+def _load_plugins(plugin_places=[misc.execution_path('plugins')],
+                  category_filter={},
+                  filter_func=lambda *arg: True):
     pm = PluginManager(plugin_info_ext='plugin')
 
     # Normalize the paths to the location of this file.
@@ -13,29 +20,55 @@ def load_env_plugin(plugin_places=[misc.execution_path('plugins')],
     plugin_places = [misc.execution_path(x) for x in plugin_places]
 
     pm.setPluginPlaces(plugin_places)
-    pm.setCategoriesFilter({"RuntimeEnvironment": IRuntimeEnvironment})
+    pm.setCategoriesFilter(category_filter)
     pm.collectPlugins()
 
     for env_plugin in pm.getAllPlugins():
-        # There should be only one plugin of the given category and type;
-        # but in case there are more, pick the first one.
-        if env_plugin.plugin_object.get_environment_name() == environment:
-            return env_plugin.plugin_object
-    raise RuntimeEnvironmentPluginNotFound('Could not find a valid "%s" '
-                                           'environment plugin at %s' %
-                                           (environment, plugin_places))
+        if filter_func(env_plugin.plugin_object):
+            yield env_plugin.plugin_object
 
 
 def reload_env_plugin(plugin_places=[misc.execution_path('plugins')],
                       environment='cloudsight'):
     global runtime_env
-    runtime_env = load_env_plugin(plugin_places, environment)
+    _plugins = _load_plugins(plugin_places,
+                             category_filter={"env": IRuntimeEnvironment},
+                             filter_func=lambda plugin:
+                             plugin.get_environment_name() == environment)
 
-# default runtime environment: cloudsigth and plugins in 'plugins/'
-runtime_env = load_env_plugin(plugin_places=[misc.execution_path('plugins')],
-                              environment='cloudsight')
+    try:
+        runtime_env = list(_plugins)[0]
+    except TypeError:
+        raise RuntimeEnvironmentPluginNotFound('Could not find a valid "%s" '
+                                               'environment plugin at %s' %
+                                               (environment, plugin_places))
+
+    return runtime_env
 
 
 def get_runtime_env_plugin():
     global runtime_env
+    if not runtime_env:
+        runtime_env = reload_env_plugin()
     return runtime_env
+
+
+def reload_container_crawl_plugins(
+        plugin_places=[misc.execution_path('plugins')],
+        features='os'):
+    global container_crawl_plugins
+    container_crawl_plugins = list(
+        _load_plugins(
+            plugin_places,
+            category_filter={
+                "crawler": IContainerCrawler},
+            filter_func=lambda plugin:
+            plugin.get_feature() in features.split(',')))
+    # Filtering of features is a temp fix.
+    # TODO remove the filtering of features after we move all
+    # features to be plugins.
+
+
+def get_container_crawl_plugins():
+    global container_crawl_plugins
+    return container_crawl_plugins


### PR DESCRIPTION
@sahilsuneja1 @sastryduri this is the change for moving os crawling to a plugin. Next step is to move all the other functions in features_crawler to plugins. The plan is to do all changes while keeping all the functionality (i.e. all tests passing), and test coverage >= 90. So as you move code from features_crawler to plugin you need to add tests for the plugins. Notice that this one is missing a test.

The other thing I want to double check with you is whether to make all the changes on the cloudviz repo/master branch. I would prefer to do so, so we can all keep contributing to the same _working_ branch. For example, we have to keep working on https://github.com/cloudviz/agentless-system-crawler/issues/137.

Signed-off-by: Ricardo Koller <kollerr@us.ibm.com>