### PR TITLE
fixed cgroup dir path fetching for kernel 4.x (cpu,cpuacct)

### DIFF
--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -224,29 +224,29 @@ class DockerContainer(Container):
 
     # Find the mount point of the specified cgroup
 
-    def _get_cgroup_dir(self, dev=''):
-        paths = [os.path.join('/cgroup/', dev),
-                 os.path.join('/sys/fs/cgroup/', dev)]
-        for path in paths:
-            if os.path.ismount(path):
-                return path
+    def _get_cgroup_dir(self, devlist=[]):
+        for dev in devlist:
+            paths = [os.path.join('/cgroup/', dev),
+                     os.path.join('/sys/fs/cgroup/', dev)]
+            for path in paths:
+                if os.path.ismount(path):
+                    return path
 
-        # Try getting the mount point from /proc/mounts
-        for l in open('/proc/mounts', 'r'):
-            _type, mnt, _, _, _, _ = l.split(' ')
-            if _type == 'cgroup' and mnt.endswith('cgroup/' + dev):
-                return mnt
+            # Try getting the mount point from /proc/mounts
+            for l in open('/proc/mounts', 'r'):
+                _type, mnt, _, _, _, _ = l.split(' ')
+                if _type == 'cgroup' and mnt.endswith('cgroup/' + dev):
+                    return mnt
 
         raise ContainerWithoutCgroups('Can not find the cgroup dir')
 
     def get_memory_cgroup_path(self, node='memory.stat'):
-        return os.path.join(self._get_cgroup_dir('memory'), 'docker',
+        return os.path.join(self._get_cgroup_dir(['memory']), 'docker',
                             self.long_id, node)
 
     def get_cpu_cgroup_path(self, node='cpuacct.usage'):
         # In kernels 4.x, the node is actually called 'cpu,cpuacct'
-        cgroup_dir = (self._get_cgroup_dir('cpuacct') or
-                      self._get_cgroup_dir('cpu,cpuacct'))
+        cgroup_dir = self._get_cgroup_dir(['cpuacct','cpu,cpuacct'])
         return os.path.join(cgroup_dir, 'docker', self.long_id, node)
 
     def __str__(self):

--- a/tests/unit/test_dockercontainer.py
+++ b/tests/unit/test_dockercontainer.py
@@ -232,7 +232,6 @@ class DockerDockerContainerTests(unittest.TestCase):
             mock_inspect,
             mocked_get_runtime_env,
             mocked_dockerps):
-        n = 0
         ids = [c.short_id for c in list_docker_containers(user_list='1,2,8')]
         assert set(ids) == set(['1', '2', '8'])
         assert mocked_get_runtime_env.call_count == 3
@@ -496,7 +495,8 @@ class DockerDockerContainerTests(unittest.TestCase):
                 side_effect=mocked_get_rootfs)
     @mock.patch(
         'crawler.dockercontainer.os.path.ismount',
-        side_effect=lambda x: True if x == '/cgroup/cpuacct' else False)
+        side_effect=lambda x:
+            True if x == '/cgroup/cpuacct' or '/cgroup/cpu,cpuacct' else False)
     def test_cpu_cgroup(
             self,
             mocked_ismount,
@@ -506,7 +506,8 @@ class DockerDockerContainerTests(unittest.TestCase):
             mocked_dockerps):
         c = DockerContainer("good_id")
         assert c.get_cpu_cgroup_path(
-            'abc') == '/cgroup/cpuacct/docker/good_id/abc'
+            'abc') == ("/cgroup/cpuacct/docker/good_id/"
+                       "abc") or ("cgroup/cpu,cpuacct/docker/good_id/abc")
 
     @mock.patch('crawler.dockercontainer.exec_dockerps',
                 side_effect=mocked_exec_dockerps)


### PR DESCRIPTION
Signed-off-by: Sahil Suneja <sahilsuneja@gmail.com>

previous code raises exception before trying alternate cgroup dir 'cpu,cpuacct'

