### PR TITLE
Some plugin fixes

### DIFF
--- a/crawler/plugins/config_container_crawler.py
+++ b/crawler/plugins/config_container_crawler.py
@@ -34,9 +34,7 @@ class ConfigContainerCrawler(IContainerCrawler):
             exclude_dirs = [misc.join_abs_paths(rootfs_dir, d)
                             for d in exclude_dirs]
             return crawl_config_files(
-                # XXX: following fails but should work
-                # root_dir=misc.join_abs_paths(rootfs_dir, root_dir),
-                root_dir,
+                root_dir=misc.join_abs_paths(rootfs_dir, root_dir),
                 exclude_dirs=exclude_dirs,
                 root_dir_alias=root_dir,
                 known_config_files=known_config_files,

--- a/crawler/plugins/config_crawler.py
+++ b/crawler/plugins/config_crawler.py
@@ -68,8 +68,8 @@ def crawl_config_files(
 
     for fpath in config_file_set:
         (_, fname) = os.path.split(fpath)
-        frelpath = fpath.replace(root_dir, root_dir_alias,
-                                 1)  # root_dir relative path
+        # realpath sanitizes the path a bit, for example: '//abc/' to '/abc/'
+        frelpath = os.path.realpath(fpath.replace(root_dir, root_dir_alias, 1))
         with codecs.open(filename=fpath, mode='r',
                          encoding='utf-8', errors='ignore') as \
                 config_file:

--- a/crawler/plugins/package_container_crawler.py
+++ b/crawler/plugins/package_container_crawler.py
@@ -41,7 +41,7 @@ class PackageContainerCrawler(IContainerCrawler):
                 container_id)
             return crawl_packages(
                 root_dir=join_abs_paths(rootfs_dir, root_dir),
-                reload_needed=False)    # XXX: shouldn't this arg be 'True'?
+                reload_needed=True)
         else:  # in all other cases, including wrong mode set
             try:
                 return run_as_another_namespace(pid,


### PR DESCRIPTION
- config_crawler in avoid setns mode was emitting //abc instead of /abc
- package crawler in avoid setns mode was not reloading the database

Signed-off-by: Ricardo Koller <kollerr@us.ibm.com>