### PR TITLE
cleaner cli overwrite over crawler.conf's plugin args

### DIFF
--- a/crawler/config_parser.py
+++ b/crawler/config_parser.py
@@ -32,25 +32,6 @@ def apply_user_args(options={}, params={}):
     except KeyError as exc:
         logger.warning('Can not apply users --options configuration: %s' % exc)
 
-    # apply per plugin configs
-    crawlers = _config['crawlers']
-    for feature in params['features']:
-        for target in {'container', 'host', 'vm'}:
-            try:
-                plugin = '%s_%s' % (feature, target)
-                crawlers[plugin] = {}
-                if feature in options:
-                    for arg in options[feature]:
-                        crawlers[plugin][arg] = options[feature][arg]
-
-                # Copy general user args to all plugins configs
-                crawlers[plugin]['avoid_setns'] = options['avoid_setns']
-                crawlers[plugin]['root_dir'] = options['mountpoint']
-            except KeyError as exc:
-                logger.warning(
-                    'Can not apply users --options configuration: %s' %
-                    exc)
-
 
 def get_config():
     global _config

--- a/crawler/crawlutils.py
+++ b/crawler/crawlutils.py
@@ -417,6 +417,43 @@ def _get_next_iteration_time(next_iteration_time, frequency, snapshot_time):
     return (time_to_sleep, next_iteration_time)
 
 
+def load_plugins(
+    features=config_parser.get_config()['general']['features_to_crawl'],
+    options={}
+):
+    environment = options.get(
+        'environment',
+        config_parser.get_config()['general']['environment'])
+
+    plugin_places = options.get(
+        'plugin_places',
+        config_parser.get_config()['general']['plugin_places'])
+
+    plugin_mode = config_parser.get_config()['general']['plugin_mode']
+
+    plugins_manager.reload_env_plugin(
+        plugin_places=plugin_places,
+        environment=environment)
+
+    plugins_manager.reload_container_crawl_plugins(
+        plugin_places=plugin_places,
+        features=features,
+        plugin_mode=plugin_mode,
+        options=options)
+
+    plugins_manager.reload_vm_crawl_plugins(
+        plugin_places=plugin_places,
+        features=features,
+        plugin_mode=plugin_mode,
+        options=options)
+
+    plugins_manager.reload_host_crawl_plugins(
+        plugin_places=plugin_places,
+        features=features,
+        plugin_mode=plugin_mode,
+        options=options)
+
+
 def snapshot(
     urls=['stdout://'],
     namespace=misc.get_host_ipaddr(),
@@ -448,36 +485,13 @@ def snapshot(
     saved_args = locals()
     logger.debug('snapshot args: %s' % (saved_args))
 
-    environment = options.get(
-        'environment',
-        config_parser.get_config()['general']['environment'])
-    plugin_places = options.get(
-        'plugin_places',
-        config_parser.get_config()['general']['plugin_places'])
-
     compress = config_parser.get_config()['general']['compress']
-
-    plugins_manager.reload_env_plugin(plugin_places=plugin_places,
-                                      environment=environment)
+    plugin_mode = config_parser.get_config()['general']['plugin_mode']
     environment = options.get(
         'environment',
         config_parser.get_config()['general']['environment'])
-    plugin_mode = config_parser.get_config()['general']['plugin_mode']
 
-    plugins_manager.reload_container_crawl_plugins(
-        plugin_places=plugin_places,
-        features=features,
-        plugin_mode=plugin_mode)
-
-    plugins_manager.reload_vm_crawl_plugins(
-        plugin_places=plugin_places,
-        features=features,
-        plugin_mode=plugin_mode)
-
-    plugins_manager.reload_host_crawl_plugins(
-        plugin_places=plugin_places,
-        features=features,
-        plugin_mode=plugin_mode)
+    load_plugins(features, options)
 
     next_iteration_time = None
 


### PR DESCRIPTION
Signed-off-by: Sahil Suneja <sahilsuneja@gmail.com>

- lots of argument list cleanup can be done for several functions for cleaner looking code; will do later.

- configObj may not be reading boolean values properly; see 'as_bool()' manual conversion in plugins_manager.py: get_plugin_args(). 
Two options: 
1. [FAILED] unrepr=True as argument in ConfigObj()  config_parser.py: parse_crawler_config(). 
2.  [HAVEN'T TRIED] avoid_setns = boolean() for each plugin in config_spec_and_defaults.conf