### PR TITLE
Add nginx metrics crawler plugin

### DIFF
--- a/crawler/plugins/applications/nginx/__init__.py
+++ b/crawler/plugins/applications/nginx/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-

--- a/crawler/plugins/applications/nginx/feature.py
+++ b/crawler/plugins/applications/nginx/feature.py
@@ -1,0 +1,22 @@
+from collections import namedtuple
+
+
+def get_feature(match1, match2, match3):
+    feature_attributes = NginxFeature(
+        int(match1.group(1)),
+        int(match2.group(1)),
+        int(match2.group(3)),
+        int(match3.group(1)),
+        int(match3.group(2)),
+        int(match3.group(3))
+    )
+    return feature_attributes
+
+NginxFeature = namedtuple('NginxFeature', [
+    'Connections',
+    'Accepted',
+    'Requests',
+    'Reading',
+    'Writing',
+    'Waiting'
+])

--- a/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
+++ b/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
@@ -2,7 +2,7 @@
 Name = application_nginx_container
 Module = nginx_container_crawler
 
-[Documentationtat
+[Documentation]
 Author = IBM
 Version = 0.1
 Description = "nginx httpd server"

--- a/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
+++ b/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = application_nginx_container
+Module = nginx_container_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "nginx httpd server"
+

--- a/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
+++ b/crawler/plugins/applications/nginx/nginx_container_crawler.plugin
@@ -2,7 +2,7 @@
 Name = application_nginx_container
 Module = nginx_container_crawler
 
-[Documentation]
+[Documentationtat
 Author = IBM
 Version = 0.1
 Description = "nginx httpd server"

--- a/crawler/plugins/applications/nginx/nginx_container_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_container_crawler.py
@@ -1,0 +1,53 @@
+try:
+    from icrawl_plugin import IContainerCrawler
+    from plugins.applications.nginx import nginx_crawler
+    from crawler_exceptions import CrawlError
+    import dockercontainer
+except ImportError:
+    from crawler.icrawl_plugin import IContainerCrawler
+    from crawler.plugins.applications.nginx import nginx_crawler
+    from crawler.crawler_exceptions import CrawlError
+    from crawler import dockercontainer
+import logging
+
+logger = logging.getLogger('crawlutils')
+
+
+class NginxContainerCrawler(IContainerCrawler):
+    feature_type = 'application'
+    feature_key = 'nginx'
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self, container_id=None, **kwargs):
+        c = dockercontainer.DockerContainer(container_id)
+
+        # check image name
+        if c.image_name.find(self.feature_key) == -1:
+            logger.error("%s is not %s container",
+                         c.image_name,
+                         self.feature_key)
+            raise CrawlError("%s does not have expected name for %s (name=%s)",
+                             container_id,
+                             self.feature_key,
+                             c.image_name)
+
+        # extract IP and Port information
+        ip = c.get_container_ip()
+        ports = c.get_container_ports()
+
+        # crawl all candidate ports
+        for port in ports:
+            try:
+                metrics = nginx_crawler.retrieve_metrics(ip, port)
+            except CrawlError:
+                logger.error("can't find metrics endpoint at http://%s:%s",
+                             ip,
+                             port)
+                continue
+            return [(self.feature_key, metrics, self.feature_type)]
+
+        raise CrawlError("%s has no accessible endpoint for %s",
+                         container_id,
+                         self.feature_key)

--- a/crawler/plugins/applications/nginx/nginx_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_crawler.py
@@ -1,0 +1,32 @@
+try:
+    from plugins.applications.nginx import feature
+    from crawler_exceptions import CrawlError
+except ImportError:
+    from crawler.plugins.applications.nginx import feature
+    from crawler.crawler_exceptions import CrawlError
+import urllib2
+import re
+
+
+def retrieve_status_page(host, port):
+    status_page = "http://%s:%s/nginx_status" % (host, port)
+    req = urllib2.Request(status_page)
+    response = urllib2.urlopen(req)
+    return response.read()
+
+
+def retrieve_metrics(host='localhost', port=80):
+    try:
+        status = retrieve_status_page(host, port)
+        match1 = re.search(r'Active connections:\s+(\d+)', status)
+        match2 = re.search(r'\s*(\d+)\s+(\d+)\s+(\d+)', status)
+        match3 = re.search(r'Reading:\s*(\d+)\s*Writing:\s*(\d+)\s*'
+                            'Waiting:\s*(\d+)', status)
+
+        feature_attributes = feature.get_feature(
+                match1,
+                match2,
+                match3)
+        return feature_attributes
+    except Exception:
+        raise CrawlError("no service at http://%s:%s", host, port)

--- a/crawler/plugins/applications/nginx/nginx_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_crawler.py
@@ -18,15 +18,20 @@ def retrieve_status_page(host, port):
 def retrieve_metrics(host='localhost', port=80):
     try:
         status = retrieve_status_page(host, port)
-        match1 = re.search(r'Active connections:\s+(\d+)', status)
-        match2 = re.search(r'\s*(\d+)\s+(\d+)\s+(\d+)', status)
-        match3 = re.search(r'Reading:\s*(\d+)\s*Writing:\s*(\d+)\s*'
-                            'Waiting:\s*(\d+)', status)
+    except Exception:
+        raise CrawlError("can't access to http://%s:%s",
+                         host, port)
 
+    match1 = re.search(r'Active connections:\s+(\d+)', status)
+    match2 = re.search(r'\s*(\d+)\s+(\d+)\s+(\d+)', status)
+    match3 = re.search(r'Reading:\s*(\d+)\s*Writing:\s*(\d+)\s*'
+                       'Waiting:\s*(\d+)', status)
+
+    try:
         feature_attributes = feature.get_feature(
-                match1,
-                match2,
-                match3)
+            match1,
+            match2,
+            match3)
         return feature_attributes
     except Exception:
-        raise CrawlError("no service at http://%s:%s", host, port)
+        raise CrawlError("failure to parse http://%s:%s", host, port)

--- a/crawler/plugins/applications/nginx/nginx_host_crawler.plugin
+++ b/crawler/plugins/applications/nginx/nginx_host_crawler.plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = application_nginx_host
+Module = nginx_host_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "nginx httpd server"
+

--- a/crawler/plugins/applications/nginx/nginx_host_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_host_crawler.py
@@ -20,11 +20,8 @@ class NginxHostCrawler(IHostCrawler):
         return self.feature_key
 
     def crawl(self):
-        try:
-            metrics = nginx_crawler.retrieve_metrics(
+        metrics = nginx_crawler.retrieve_metrics(
                 host='localhost',
                 port=self.default_port
-            )
-        except CrawlError as e:
-            raise e
+        )
         return [(self.feature_key, metrics, self.feature_type)]

--- a/crawler/plugins/applications/nginx/nginx_host_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_host_crawler.py
@@ -21,7 +21,7 @@ class NginxHostCrawler(IHostCrawler):
 
     def crawl(self):
         metrics = nginx_crawler.retrieve_metrics(
-                host='localhost',
-                port=self.default_port
+            host='localhost',
+            port=self.default_port
         )
         return [(self.feature_key, metrics, self.feature_type)]

--- a/crawler/plugins/applications/nginx/nginx_host_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_host_crawler.py
@@ -1,11 +1,9 @@
 try:
     from icrawl_plugin import IHostCrawler
     from plugins.applications.nginx import nginx_crawler
-    from crawler_exceptions import CrawlError
 except ImportError:
     from crawler.icrawl_plugin import IHostCrawler
     from crawler.plugins.applications.nginx import nginx_crawler
-    from crawler.crawler_exceptions import CrawlError
 import logging
 
 logger = logging.getLogger('crawlutils')

--- a/crawler/plugins/applications/nginx/nginx_host_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_host_crawler.py
@@ -1,0 +1,30 @@
+try:
+    from icrawl_plugin import IHostCrawler
+    from plugins.applications.nginx import nginx_crawler
+    from crawler_exceptions import CrawlError
+except ImportError:
+    from crawler.icrawl_plugin import IHostCrawler
+    from crawler.plugins.applications.nginx import nginx_crawler
+    from crawler.crawler_exceptions import CrawlError
+import logging
+
+logger = logging.getLogger('crawlutils')
+
+
+class NginxHostCrawler(IHostCrawler):
+    feature_type = 'application'
+    feature_key = 'nginx'
+    default_port = 80
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self):
+        try:
+            metrics = nginx_crawler.retrieve_metrics(
+                host='localhost',
+                port=self.default_port
+            )
+        except CrawlError as e:
+            raise e
+        return [(self.feature_key, metrics, self.feature_type)]

--- a/tests/unit/test_app_nginx.py
+++ b/tests/unit/test_app_nginx.py
@@ -1,0 +1,175 @@
+import mock
+import urllib2
+from unittest import TestCase
+from crawler.plugins.applications.nginx import nginx_crawler
+from crawler.plugins.applications.nginx.feature import NginxFeature
+from crawler.plugins.applications.nginx.nginx_host_crawler \
+    import NginxHostCrawler
+from crawler.plugins.applications.nginx.nginx_container_crawler \
+    import NginxContainerCrawler
+from crawler.crawler_exceptions import CrawlError
+
+
+# expected format from nginx status page
+def mocked_retrieve_status_page(host,port):
+    return ('Active connections: 2\n'
+            'server accepts handled requests\n'
+            '2 2 1\n'
+            'Reading: 0 Writing: 1 Waiting: 1'
+            )
+
+def mocked_no_status_page(host,port):
+    #raise urllib2.HTTPError(1,2,3,4,5)
+    raise Exception
+
+def mocked_wrong_status_page(host,port):
+    return ('No Acceptable status page format')
+
+def mocked_urllib2_open(request):
+    return MockedURLResponse()
+
+class MockedURLResponse(object):
+    def read(self):
+        return ('Active connections: 2\n'
+            'server accepts handled requests\n'
+            '2 2 1\n'
+            'Reading: 0 Writing: 1 Waiting: 1'
+            )
+
+class MockedNginxContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'nginx-container'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = [80, 443]
+        return ports
+
+class MockedNoPortContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'nginx-container'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = []
+        return ports
+
+class MockedNoNameContainer(object):
+    def __init__(self,container_id):
+        self.image_name = 'dummy'
+
+class NginxCrawlTests(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('urllib2.urlopen', mocked_urllib2_open)
+    def test_ok(self):
+        self.assertIsInstance(nginx_crawler.retrieve_metrics(),
+                              NginxFeature)
+
+    '''
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    def test_successful_crawling(self):
+        self.assertIsInstance(nginx_crawler.retrieve_metrics(),
+                              NginxFeature)
+    '''
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_no_status_page)
+    def test_hundle_ioerror(self):
+        with self.assertRaises(CrawlError):
+            nginx_crawler.retrieve_metrics()
+
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_wrong_status_page)
+    def test_hundle_parseerror(self):
+        with self.assertRaises(CrawlError):
+            nginx_crawler.retrieve_metrics()
+
+
+class NginxHostTest(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = NginxHostCrawler()
+        self.assertEqual(c.get_feature(), 'nginx')
+
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    def test_get_metrics(self):
+        c = NginxHostCrawler()
+        emitted = c.crawl()[0]
+        self.assertEqual(emitted[0], 'nginx')
+        self.assertIsInstance(emitted[1], NginxFeature)
+        self.assertEqual(emitted[2], 'application')
+
+class NginxContainerTest(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = NginxContainerCrawler()
+        self.assertEqual(c.get_feature(), 'nginx')
+
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    @mock.patch('crawler.dockercontainer.DockerContainer',
+                MockedNginxContainer)
+    def test_get_metrics(self):
+        c = NginxContainerCrawler()
+        emitted = c.crawl()[0]
+        self.assertEqual(emitted[0], 'nginx')
+        self.assertIsInstance(emitted[1], NginxFeature)
+        self.assertEqual(emitted[2], 'application')
+
+    @mock.patch('crawler.dockercontainer.DockerContainer',
+                MockedNoPortContainer)
+    def test_no_available_port(self):
+        c = NginxContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")
+
+    @mock.patch('crawler.dockercontainer.DockerContainer',
+                MockedNoNameContainer)
+    def test_none_nginx_container(self):
+        c = NginxContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")
+
+    @mock.patch('crawler.plugins.applications.nginx.'
+                'nginx_crawler.retrieve_status_page',
+                mocked_no_status_page)
+    @mock.patch('crawler.dockercontainer.DockerContainer',
+                MockedNginxContainer)
+    def test_no_accessible_endpoint(self):
+        c = NginxContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")

--- a/tests/unit/test_app_nginx.py
+++ b/tests/unit/test_app_nginx.py
@@ -11,30 +11,36 @@ from crawler.crawler_exceptions import CrawlError
 
 
 # expected format from nginx status page
-def mocked_retrieve_status_page(host,port):
+def mocked_retrieve_status_page(host, port):
     return ('Active connections: 2\n'
             'server accepts handled requests\n'
             '2 2 1\n'
             'Reading: 0 Writing: 1 Waiting: 1'
             )
 
-def mocked_no_status_page(host,port):
+
+def mocked_no_status_page(host, port):
     #raise urllib2.HTTPError(1,2,3,4,5)
     raise Exception
 
-def mocked_wrong_status_page(host,port):
+
+def mocked_wrong_status_page(host, port):
     return ('No Acceptable status page format')
+
 
 def mocked_urllib2_open(request):
     return MockedURLResponse()
 
+
 class MockedURLResponse(object):
+
     def read(self):
         return ('Active connections: 2\n'
-            'server accepts handled requests\n'
-            '2 2 1\n'
-            'Reading: 0 Writing: 1 Waiting: 1'
-            )
+                'server accepts handled requests\n'
+                '2 2 1\n'
+                'Reading: 0 Writing: 1 Waiting: 1'
+                )
+
 
 class MockedNginxContainer(object):
 
@@ -51,6 +57,7 @@ class MockedNginxContainer(object):
         ports = [80, 443]
         return ports
 
+
 class MockedNoPortContainer(object):
 
     def __init__(
@@ -66,9 +73,12 @@ class MockedNoPortContainer(object):
         ports = []
         return ports
 
+
 class MockedNoNameContainer(object):
-    def __init__(self,container_id):
+
+    def __init__(self, container_id):
         self.image_name = 'dummy'
+
 
 class NginxCrawlTests(TestCase):
 
@@ -107,6 +117,7 @@ class NginxCrawlTests(TestCase):
 
 
 class NginxHostTest(TestCase):
+
     def setUp(self):
         pass
 
@@ -127,7 +138,9 @@ class NginxHostTest(TestCase):
         self.assertIsInstance(emitted[1], NginxFeature)
         self.assertEqual(emitted[2], 'application')
 
+
 class NginxContainerTest(TestCase):
+
     def setUp(self):
         pass
 

--- a/tests/unit/test_app_redis.py
+++ b/tests/unit/test_app_redis.py
@@ -156,6 +156,7 @@ class MockedRedisContainer3(object):
         ports = []
         return ports
 
+
 class MockedRedisContainer4(object):
 
     def __init__(
@@ -221,7 +222,7 @@ class RedisContainerCrawlTests(TestCase):
                 MockedRedisContainer4)
     @mock.patch('redis.Redis', MockedRedisClient2)
     def test_no_available_ports(self):
-        c = RedisHostCrawler()
+        c = RedisContainerCrawler()
         with self.assertRaises(ConnectionError):
             c.crawl("mockcontainerid")
 


### PR DESCRIPTION
This PR supports to gather nginx provided metrics.
The detail design is described at issue #196.