### PR TITLE
Fix: return no feature attributes in redis plugin

### DIFF
--- a/crawler/plugins/applications/redis/feature.py
+++ b/crawler/plugins/applications/redis/feature.py
@@ -1,7 +1,12 @@
 from collections import namedtuple
 
-
 def create_feature(metrics):
+    fields = RedisFeature._fields
+
+    for field_name in fields:
+	if not metrics.has_key(field_name):
+	    metrics[field_name] = ""
+
     feature_attributes = RedisFeature(
         metrics['aof_current_rewrite_time_sec'],
         metrics['aof_enabled'],
@@ -84,7 +89,6 @@ def create_feature(metrics):
         metrics['used_memory_rss_human']
     )
     return feature_attributes
-
 
 RedisFeature = namedtuple('RedisFeature', [
     'aof_current_rewrite_time_sec',

--- a/crawler/plugins/applications/redis/feature.py
+++ b/crawler/plugins/applications/redis/feature.py
@@ -1,11 +1,12 @@
 from collections import namedtuple
 
+
 def create_feature(metrics):
     fields = RedisFeature._fields
 
     for field_name in fields:
-	if not metrics.has_key(field_name):
-	    metrics[field_name] = ""
+        if field_name not in metrics:
+            metrics[field_name] = ""
 
     feature_attributes = RedisFeature(
         metrics['aof_current_rewrite_time_sec'],


### PR DESCRIPTION
Bug fix patch of  [#277](https://github.com/cloudviz/agentless-system-crawler/issues/227).
If "metric" does not have all keys, a dummy key and value pair is added to the hash list. 