### PR TITLE
Add apache httpd metrics crawler plugin

### DIFF
--- a/crawler/plugins/applications/apache/__init__.py
+++ b/crawler/plugins/applications/apache/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-

--- a/crawler/plugins/applications/apache/apache_container_crawler.plugin
+++ b/crawler/plugins/applications/apache/apache_container_crawler.plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = apache_container
+Module = apache_container_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "Apache httpd server"
+

--- a/crawler/plugins/applications/apache/apache_container_crawler.py
+++ b/crawler/plugins/applications/apache/apache_container_crawler.py
@@ -1,0 +1,51 @@
+import logging
+
+
+import dockercontainer
+from icrawl_plugin import IContainerCrawler
+from plugins.applications.apache import apache_crawler
+from utils.crawler_exceptions import CrawlError
+
+logger = logging.getLogger('crawlutils')
+
+
+class ApacheContainerCrawler(IContainerCrawler):
+    feature_type = 'application'
+    feature_key = 'apache'
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self, container_id=None, **kwargs):
+
+        c = dockercontainer.DockerContainer(container_id)
+
+        # check image name
+        if c.image_name.find("httpd") == -1:
+
+            logger.error("%s is not %s container",
+                         c.image_name,
+                         self.feature_key)
+            raise CrawlError("%s does not have expected name for %s (name=%s)",
+                             container_id,
+                             self.feature_key,
+                             c.image_name)
+
+        # extract IP and Port information
+        ip = c.get_container_ip()
+        ports = c.get_container_ports()
+
+        # crawl all candidate ports
+        for port in ports:
+            try:
+                metrics = apache_crawler.retrieve_metrics(ip, port)
+            except CrawlError:
+                logger.error("can't find metrics endpoint at http://%s:%s",
+                             ip,
+                             port)
+                continue
+            return [(self.feature_key, metrics, self.feature_type)]
+
+        raise CrawlError("%s has no accessible endpoint for %s",
+                         container_id,
+                         self.feature_key)

--- a/crawler/plugins/applications/apache/apache_crawler.py
+++ b/crawler/plugins/applications/apache/apache_crawler.py
@@ -79,12 +79,13 @@ def retrieve_metrics(host='localhost', port=80):
             stats['Total_Accesses'] = res[1]
 
     feature_attributes = feature.ApacheFeature
+
+    if len(stats) == 0:
+        raise CrawlError("failure to parse http://%s:%s", host, port)
+
     for name in feature_attributes._fields:
         if name not in stats:
             stats[name] = '0'
 
-    try:
-        feature_attributes = feature.get_feature(stats)
-        return feature_attributes
-    except Exception:
-        raise CrawlError("failure to parse http://%s:%s", host, port)
+    feature_attributes = feature.get_feature(stats)
+    return feature_attributes

--- a/crawler/plugins/applications/apache/apache_crawler.py
+++ b/crawler/plugins/applications/apache/apache_crawler.py
@@ -1,0 +1,90 @@
+
+
+import urllib2
+from plugins.applications.apache import feature
+from collections import defaultdict
+from utils.crawler_exceptions import CrawlError
+
+
+def retrieve_status_page(host, port):
+    statusPage = "http://%s:%s/server-status?auto" % (host, port)
+    req = urllib2.Request(statusPage)
+    response = urllib2.urlopen(req)
+    return response.read()
+
+
+def retrieve_metrics(host='localhost', port=80):
+    try:
+        status = retrieve_status_page(host, port).splitlines()
+    except Exception:
+        raise CrawlError("can't access to http://%s:%s",
+                         host, port)
+    stats = {}
+
+    line_num = 0
+    for line in status:
+        line_num += 1
+
+        if "BusyWorkers" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "IdleWorkers" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "Scoreboard" in line:
+            res = line.split(': ')
+
+            workcounts = defaultdict(int)
+            for i in res[1]:
+                workcounts[i] += 1
+
+            for x, y in workcounts.iteritems():
+                if x == "_":
+                    stats['waiting_for_connection'] = str(y)
+                elif x == "S":
+                    stats['starting_up'] = str(y)
+                elif x == "R":
+                    stats['reading_request'] = str(y)
+                elif x == "W":
+                    stats['sending_reply'] = str(y)
+                elif x == "K":
+                    stats['keepalive_read'] = str(y)
+                elif x == "D":
+                    stats['dns_lookup'] = str(y)
+                elif x == "C":
+                    stats['closing_connection'] = str(y)
+                elif x == "L":
+                    stats['logging'] = str(y)
+                elif x == "G":
+                    stats['graceful_finishing'] = str(y)
+                elif x == "I":
+                    stats['idle_worker_cleanup'] = str(y)
+        elif "BytesPerSec" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "BytesPerReq" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "ReqPerSec" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "Uptime" in line:
+            res = line.split(': ')
+            stats[res[0]] = res[1]
+        elif "Total kBytes" in line:
+            res = line.split(': ')
+            stats['Total_kBytes'] = res[1]
+        elif "Total Accesses" in line:
+            res = line.split(': ')
+            stats['Total_Accesses'] = res[1]
+
+    feature_attributes = feature.ApacheFeature
+    for name in feature_attributes._fields:
+        if name not in stats:
+            stats[name] = '0'
+
+    try:
+        feature_attributes = feature.get_feature(stats)
+        return feature_attributes
+    except Exception:
+        raise CrawlError("failure to parse http://%s:%s", host, port)

--- a/crawler/plugins/applications/apache/apache_host_crawler.plugin
+++ b/crawler/plugins/applications/apache/apache_host_crawler.plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = apache_host
+Module = apache_host_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "Apache httpd server"
+

--- a/crawler/plugins/applications/apache/apache_host_crawler.py
+++ b/crawler/plugins/applications/apache/apache_host_crawler.py
@@ -1,0 +1,21 @@
+from icrawl_plugin import IHostCrawler
+from plugins.applications.apache import apache_crawler
+import logging
+
+logger = logging.getLogger('crawlutils')
+
+
+class ApacheHostCrawler(IHostCrawler):
+    feature_type = 'application'
+    feature_key = 'apache'
+    default_port = 80
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self):
+        metrics = apache_crawler.retrieve_metrics(
+            host='localhost',
+            port=self.default_port
+        )
+        return [(self.feature_key, metrics, self.feature_type)]

--- a/crawler/plugins/applications/apache/feature.py
+++ b/crawler/plugins/applications/apache/feature.py
@@ -1,0 +1,46 @@
+from collections import namedtuple
+
+
+def get_feature(stats):
+    feature_attributes = ApacheFeature(
+        stats['BusyWorkers'],
+        stats['IdleWorkers'],
+        stats['waiting_for_connection'],
+        stats['starting_up'],
+        stats['reading_request'],
+        stats['sending_reply'],
+        stats['keepalive_read'],
+        stats['dns_lookup'],
+        stats['closing_connection'],
+        stats['logging'],
+        stats['graceful_finishing'],
+        stats['idle_worker_cleanup'],
+        stats['BytesPerSec'],
+        stats['BytesPerReq'],
+        stats['ReqPerSec'],
+        stats['Uptime'],
+        stats['Total_kBytes'],
+        stats['Total_Accesses']
+    )
+    return feature_attributes
+
+ApacheFeature = namedtuple('ApacheFeature', [
+    'BusyWorkers',
+    'IdleWorkers',
+    'waiting_for_connection',
+    'starting_up',
+    'reading_request',
+    'sending_reply',
+    'keepalive_read',
+    'dns_lookup',
+    'closing_connection',
+    'logging',
+    'graceful_finishing',
+    'idle_worker_cleanup',
+    'BytesPerSec',
+    'BytesPerReq',
+    'ReqPerSec',
+    'Uptime',
+    'Total_kBytes',
+    'Total_Accesses'
+])

--- a/crawler/plugins/applications/redis/feature.py
+++ b/crawler/plugins/applications/redis/feature.py
@@ -1,11 +1,12 @@
 from collections import namedtuple
 
+
 def create_feature(metrics):
     fields = RedisFeature._fields
 
     for field_name in fields:
-	if not metrics.has_key(field_name):
-	    metrics[field_name] = ""
+        if field_name not in metrics:
+            metrics[field_name] = ""
 
     feature_attributes = RedisFeature(
         metrics['aof_current_rewrite_time_sec'],

--- a/tests/unit/test_app_apache.py
+++ b/tests/unit/test_app_apache.py
@@ -1,0 +1,259 @@
+from unittest import TestCase
+
+import mock
+
+from plugins.applications.apache import apache_crawler
+from plugins.applications.apache.feature import ApacheFeature
+from plugins.applications.apache.apache_container_crawler \
+    import ApacheContainerCrawler
+from plugins.applications.apache.apache_host_crawler \
+    import ApacheHostCrawler
+from utils.crawler_exceptions import CrawlError
+
+
+# expected format from apache status page
+
+def mocked_wrong_status_page(host, port):
+    return ('No Acceptable status page format')
+
+
+def mocked_urllib2_open(request):
+    return MockedURLResponse()
+
+
+def mocked_urllib2_open_with_zero(request):
+    return MockedURLResponseWithZero()
+
+
+def mocked_no_status_page(host, port):
+    raise Exception
+
+
+def mocked_retrieve_status_page(host, port):
+    return ('Total Accesses: 172\n'
+            'Total kBytes: 1182\n'
+            'CPULoad: 2.34827\n'
+            'Uptime: 1183\n'
+            'ReqPerSec: .145393\n'
+            'BytesPerSec: 1023.13\n'
+            'BytesPerReq: 7037.02\n'
+            'BusyWorkers: 2\n'
+            'IdleWorkers: 9\n'
+            'Scoreboard: __R_W______......G..C...'
+            'DSKLI...............................'
+            '...................................................'
+            )
+
+
+class MockedURLResponse(object):
+
+    def read(self):
+        return ('Total Accesses: 172\n'
+                'Total kBytes: 1182\n'
+                'CPULoad: 2.34827\n'
+                'Uptime: 1183\n'
+                'ReqPerSec: .145393\n'
+                'BytesPerSec: 1023.13\n'
+                'BytesPerReq: 7037.02\n'
+                'BusyWorkers: 2\n'
+                'IdleWorkers: 9\n'
+                'Scoreboard: __R_W______......G..'
+                'C...DSKLI........................'
+                '..........................................................'
+                )
+
+
+class MockedURLResponseWithZero(object):
+
+    def read(self):
+        return ('Total Accesses: 172\n'
+                'Total kBytes: 1182\n'
+                'CPULoad: 2.34827\n'
+                'ReqPerSec: .145393\n'
+                'BytesPerSec: 1023.13\n'
+                'BytesPerReq: 7037.02\n'
+                'BusyWorkers: 2\n'
+                'IdleWorkers: 9\n'
+                'Scoreboard: __R_W______......G..C...'
+                'DSKLI................................'
+                '..................................................'
+                )
+
+
+class MockedApacheContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'httpd-container'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = [80, 443]
+        return ports
+
+
+class MockedNoPortContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'httpd-container'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = []
+        return ports
+
+
+class MockedNoNameContainer(object):
+
+    def __init__(self, container_id):
+        self.image_name = 'dummy'
+
+
+class ApacheCrawlTests(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('urllib2.urlopen', mocked_urllib2_open_with_zero)
+    def test_ok_with_zero(self):
+        status = apache_crawler.retrieve_metrics()
+        assert status == ApacheFeature(
+            BusyWorkers='2',
+            IdleWorkers='9',
+            waiting_for_connection='9',
+            starting_up='1',
+            reading_request='1',
+            sending_reply='1',
+            keepalive_read='1',
+            dns_lookup='1',
+            closing_connection='1',
+            logging='1',
+            graceful_finishing='1',
+            idle_worker_cleanup='1',
+            BytesPerSec='1023.13',
+            BytesPerReq='7037.02',
+            ReqPerSec='.145393',
+            Uptime='0',
+            Total_kBytes='1182',
+            Total_Accesses='172')
+
+    @mock.patch('urllib2.urlopen', mocked_urllib2_open)
+    def test_ok(self):
+        status = apache_crawler.retrieve_metrics()
+        assert status == ApacheFeature(
+            BusyWorkers='2',
+            IdleWorkers='9',
+            waiting_for_connection='9',
+            starting_up='1',
+            reading_request='1',
+            sending_reply='1',
+            keepalive_read='1',
+            dns_lookup='1',
+            closing_connection='1',
+            logging='1',
+            graceful_finishing='1',
+            idle_worker_cleanup='1',
+            BytesPerSec='1023.13',
+            BytesPerReq='7037.02',
+            ReqPerSec='.145393',
+            Uptime='1183',
+            Total_kBytes='1182',
+            Total_Accesses='172')
+
+    @mock.patch('plugins.applications.apache.'
+                'apache_crawler.retrieve_status_page',
+                mocked_no_status_page)
+    def test_hundle_ioerror(self):
+        with self.assertRaises(CrawlError):
+            apache_crawler.retrieve_metrics()
+
+    @mock.patch('plugins.applications.apache.'
+                'apache_crawler.retrieve_status_page',
+                mocked_wrong_status_page)
+    def test_hundle_parseerror(self):
+        with self.assertRaises(CrawlError):
+            apache_crawler.retrieve_metrics()
+
+
+class ApacheHostTest(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = ApacheHostCrawler()
+        self.assertEqual(c.get_feature(), 'apache')
+
+    @mock.patch('plugins.applications.apache.'
+                'apache_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    def test_get_metrics(self):
+        c = ApacheHostCrawler()
+        emitted = c.crawl()[0]
+        self.assertEqual(emitted[0], 'apache')
+        self.assertIsInstance(emitted[1], ApacheFeature)
+        self.assertEqual(emitted[2], 'application')
+
+
+class ApacheContainerTest(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = ApacheContainerCrawler()
+        self.assertEqual(c.get_feature(), 'apache')
+
+    @mock.patch('plugins.applications.apache.'
+                'apache_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedApacheContainer)
+    def test_get_metrics(self):
+        c = ApacheContainerCrawler()
+        emitted = c.crawl()[0]
+        self.assertEqual(emitted[0], 'apache')
+        self.assertIsInstance(emitted[1], ApacheFeature)
+        self.assertEqual(emitted[2], 'application')
+
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedNoPortContainer)
+    def test_no_available_port(self):
+        c = ApacheContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")
+
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedNoNameContainer)
+    def test_none_apache_container(self):
+        c = ApacheContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")
+
+    @mock.patch('plugins.applications.apache.'
+                'apache_crawler.retrieve_status_page',
+                mocked_no_status_page)
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedApacheContainer)
+    def test_no_accessible_endpoint(self):
+        c = ApacheContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")

--- a/tests/unit/test_app_redis.py
+++ b/tests/unit/test_app_redis.py
@@ -1,11 +1,13 @@
 import mock
 from unittest import TestCase
 from plugins.applications.redis.feature import RedisFeature
+from plugins.applications.redis.feature import create_feature
 from plugins.applications.redis.redis_host_crawler \
     import RedisHostCrawler
 from plugins.applications.redis.redis_container_crawler \
     import RedisContainerCrawler
 from requests.exceptions import ConnectionError
+import redis
 
 
 class MockedRedisClient(object):
@@ -107,6 +109,22 @@ class MockedRedisClient2(object):
 
     def info(self):
         raise ConnectionError()
+
+
+class MockedRedisClient3(object):
+
+    def __init__(self, host='localhost', port=6379):
+        self.host = host
+        self.port = port
+
+    def info(self):
+        metrics = {
+            "aof_current_rewrite_time_sec": -1,
+            "aof_enabled": 0,
+            "tcp_port": 6379,
+            "used_memory_rss_human": "6.69M"
+        }
+        return metrics
 
 
 class MockedRedisContainer1(object):
@@ -247,6 +265,12 @@ class RedisHostCrawlTests(TestCase):
     def test_get_feature(self):
         c = RedisHostCrawler()
         self.assertEqual(c.get_feature(), "application")
+
+    @mock.patch('redis.Redis', MockedRedisClient3)
+    def test_redis_host_crawler_dummy(self):
+        client = redis.Redis()
+        feature_attributes = create_feature(client.info())
+        self.assertEqual(feature_attributes[0], -1)
 
     def test_redis_host_crawler(self):
         with mock.patch('redis.Redis', MockedRedisClient):


### PR DESCRIPTION
This PR supports to gather apache httpd server provided metrics.
The detail information is described at issue #238 