### PR TITLE
Add tomcat metrics crawler plugin

### DIFF
--- a/crawler/plugins/applications/apache/apache_container_crawler.plugin
+++ b/crawler/plugins/applications/apache/apache_container_crawler.plugin
@@ -1,5 +1,5 @@
 [Core]
-Name = apache_container
+Name = application_apache_container
 Module = apache_container_crawler
 
 [Documentation]

--- a/crawler/plugins/applications/apache/apache_crawler.py
+++ b/crawler/plugins/applications/apache/apache_crawler.py
@@ -1,5 +1,3 @@
-
-
 import urllib2
 from plugins.applications.apache import feature
 from collections import defaultdict

--- a/crawler/plugins/applications/apache/apache_crawler.py
+++ b/crawler/plugins/applications/apache/apache_crawler.py
@@ -55,10 +55,7 @@ def retrieve_metrics(host='localhost', port=80):
 
     stats = {}
 
-    line_num = 0
     for line in status:
-        line_num += 1
-
         if "Scoreboard" in line:
             parse_score_board(line, stats)
 

--- a/crawler/plugins/applications/apache/apache_host_crawler.plugin
+++ b/crawler/plugins/applications/apache/apache_host_crawler.plugin
@@ -1,5 +1,5 @@
 [Core]
-Name = apache_host
+Name = application_apache_host
 Module = apache_host_crawler
 
 [Documentation]

--- a/crawler/plugins/applications/tomcat/__init__.py
+++ b/crawler/plugins/applications/tomcat/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-

--- a/crawler/plugins/applications/tomcat/feature.py
+++ b/crawler/plugins/applications/tomcat/feature.py
@@ -1,0 +1,41 @@
+from collections import namedtuple
+
+
+TomcatJVMFeature = namedtuple('TomcatJVMFeature', [
+                              'free',
+                              'total',
+                              'max'
+                              ])
+
+TomcatMemoryFeature = namedtuple('TomcatMemoryFeature', [
+                                 'name',
+                                 'type',
+                                 'initial',
+                                 'committed',
+                                 'maximum',
+                                 'used'
+                                 ])
+
+TomcatConnectorFeature = namedtuple('TomcatConnectorFeature', [
+                                    'connector',
+                                    'maxThread',
+                                    'currentThread',
+                                    'currentThreadBusy',
+                                    'requestMaxTime',
+                                    'processingTime',
+                                    'requestCount',
+                                    'errorCount',
+                                    'byteReceived',
+                                    'byteSent'
+                                    ])
+
+TomcatWorkerFeature = namedtuple('TomcatWorkerFeature', [
+                                 'connector',
+                                 'stage',
+                                 'time',
+                                 'byteSent',
+                                 'byteReceived',
+                                 'client',
+                                 'vhost',
+                                 'request'
+                                 ])

--- a/crawler/plugins/applications/tomcat/tomcat_container_crawler.plugin
+++ b/crawler/plugins/applications/tomcat/tomcat_container_crawler.plugin
@@ -1,0 +1,12 @@
+[Core]
+Name = application_tomcat_container
+Module = tomcat_container_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = Tomcat crawling function for containers on the host
+
+[Options]
+user = administrator user name, Default is tomcat
+password = administrator password, Default is password

--- a/crawler/plugins/applications/tomcat/tomcat_container_crawler.py
+++ b/crawler/plugins/applications/tomcat/tomcat_container_crawler.py
@@ -1,0 +1,57 @@
+import logging
+
+import dockercontainer
+from icrawl_plugin import IContainerCrawler
+from plugins.applications.tomcat import tomcat_crawler
+from utils.crawler_exceptions import CrawlError
+
+logger = logging.getLogger('crawlutils')
+
+
+class TomcatContainerCrawler(IContainerCrawler):
+    feature_type = 'application'
+    feature_key = 'tomcat'
+    default_port = 8080
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self, container_id=None, **kwargs):
+        password = "password"
+        user = "tomcat"
+
+        if "password" in kwargs:
+            password = kwargs["password"]
+
+        if "user" in kwargs:
+            user = kwargs["user"]
+
+        c = dockercontainer.DockerContainer(container_id)
+
+        # check image name
+        if c.image_name.find(self.feature_key) == -1:
+            logger.error("%s is not %s container",
+                         c.image_name,
+                         self.feature_key)
+            raise CrawlError("%s does not have expected name for %s (name=%s)",
+                             container_id,
+                             self.feature_key,
+                             c.image_name)
+
+        # extract IP and Port information
+        ip = c.get_container_ip()
+        ports = c.get_container_ports()
+
+        # crawl all candidate ports
+        for each_port in ports:
+                return tomcat_crawler.retrieve_metrics(
+                    host=ip,
+                    port=each_port,
+                    user=user,
+                    password=password,
+                    feature_type=self.feature_type
+                )
+
+        raise CrawlError("%s has no accessible endpoint for %s",
+                         container_id,
+                         self.feature_key)

--- a/crawler/plugins/applications/tomcat/tomcat_crawler.py
+++ b/crawler/plugins/applications/tomcat/tomcat_crawler.py
@@ -1,0 +1,82 @@
+import urllib2
+from plugins.applications.tomcat import feature
+from xml.etree import ElementTree
+from utils.crawler_exceptions import CrawlError
+
+
+def retrieve_status_page(hostname, port, user, password):
+    statusPage = "http://%s:%s/manager/status?XML=true" % (hostname, port)
+
+    password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
+    password_mgr.add_password(None, statusPage, user, password)
+    handler = urllib2.HTTPBasicAuthHandler(password_mgr)
+    opener = urllib2.build_opener(handler)
+    urllib2.install_opener(opener)
+
+    req = urllib2.Request(statusPage)
+    try:
+        response = urllib2.urlopen(req)
+        return response.read()
+    except Exception:
+        raise CrawlError("can't access to http://%s:%s",
+                         hostname, port)
+
+
+def retrieve_metrics(host='localhost', port=8080,
+                     user='tomcat', password='password',
+                     feature_type='application'):
+
+    status = retrieve_status_page(host, port, user, password)
+    tree = ElementTree.XML(status)
+    memoryNode = tree.find('jvm/memory')
+    jvm_attributes = feature.TomcatJVMFeature(
+        memoryNode.get("free"),
+        memoryNode.get("total"),
+        memoryNode.get("max")
+    )
+
+    yield('tomcat_jvm', jvm_attributes, feature_type)
+
+    for node in tree.iter('memorypool'):
+        memory_pool_attributes = feature.TomcatMemoryFeature(
+            node.get("name"),
+            node.get("type"),
+            node.get("usageInit"),
+            node.get("usageCommitted"),
+            node.get("usageMax"),
+            node.get("usageUsed")
+        )
+        yield('tomcat_memory', memory_pool_attributes, feature_type)
+
+    ConnectorNode = tree.iter('connector')
+    for node in ConnectorNode:
+        threadInfo = node.find("threadInfo")
+        reqInfo = node.find("requestInfo")
+
+        connector_feature_attributes = feature.TomcatConnectorFeature(
+            node.get("name"),
+            threadInfo.get("maxThreads"),
+            threadInfo.get("currentThreadCount"),
+            threadInfo.get("currentThreadsBusy"),
+            reqInfo.get("maxTime"),
+            reqInfo.get("processingTime"),
+            reqInfo.get("requestCount"),
+            reqInfo.get("errorCount"),
+            reqInfo.get("bytesReceived"),
+            reqInfo.get("bytesSent")
+        )
+        yield('tomcat_connector', connector_feature_attributes, feature_type)
+
+        workNode = node.iter("worker")
+        for work in workNode:
+            worker_feature_attributes = feature.TomcatWorkerFeature(
+                node.get("name"),
+                work.get("stage"),
+                work.get("requestProcessingTime"),
+                work.get("requestBytesSent"),
+                work.get("requestBytesReceived"),
+                work.get("remoteAddr"),
+                work.get("virtualHost"),
+                work.get("currentUri")
+            )
+            yield('tomcat_worker', worker_feature_attributes, feature_type)

--- a/crawler/plugins/applications/tomcat/tomcat_host_crawler.plugin
+++ b/crawler/plugins/applications/tomcat/tomcat_host_crawler.plugin
@@ -1,0 +1,12 @@
+[Core]
+Name = application_tomcat_host
+Module = tomcat_host_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "Apache httpd server"
+
+[Options]
+user = administrator user name, Default is tomcat
+password = administrator password, Default is password

--- a/crawler/plugins/applications/tomcat/tomcat_host_crawler.py
+++ b/crawler/plugins/applications/tomcat/tomcat_host_crawler.py
@@ -1,0 +1,32 @@
+from icrawl_plugin import IHostCrawler
+from plugins.applications.tomcat import tomcat_crawler
+import logging
+
+logger = logging.getLogger('crawlutils')
+
+
+class TomcatHostCrawler(IHostCrawler):
+    feature_type = 'application'
+    feature_key = 'tomcat'
+    default_port = 8080
+
+    def get_feature(self):
+        return self.feature_key
+
+    def crawl(self, **options):
+        password = "password"
+        user = "tomcat"
+
+        if "password" in options:
+            password = options["password"]
+
+        if "user" in options:
+            user = options["user"]
+
+        return tomcat_crawler.retrieve_metrics(
+            host='localhost',
+            port=self.default_port,
+            user=user,
+            password=password,
+            feature_type=self.feature_type
+        )

--- a/tests/unit/test_app_tomcat.py
+++ b/tests/unit/test_app_tomcat.py
@@ -1,0 +1,275 @@
+from unittest import TestCase
+
+import mock
+
+from plugins.applications.tomcat import tomcat_crawler
+from plugins.applications.tomcat import feature
+from plugins.applications.tomcat.tomcat_container_crawler \
+    import TomcatContainerCrawler
+from plugins.applications.tomcat.tomcat_host_crawler \
+    import TomcatHostCrawler
+from utils.crawler_exceptions import CrawlError
+
+
+def mocked_urllib2_open(request):
+    return MockedURLResponse()
+
+
+def mocked_retrieve_status_page(host, port, user, password):
+    return server_status_value()
+
+
+def server_status_value():
+    return ('<?xml version="1.0" encoding="utf-8"?>'
+            '<?xml-stylesheet type="text/xsl" href="/manager/xform.xsl" ?>'
+            '<status><jvm><memory free=\'3846720\''
+            '  total=\'62390272\' max=\'922746880\'/>'
+            '<memorypool name=\'PS Eden Space\' type=\'Heap memory\''
+            ' usageInit=\'16252928\' usageCommitted=\'16252928\''
+            ' usageMax=\'340787200\' usageUsed=\'8570016\'/>'
+            '<memorypool name=\'PS Survivor Space\' type=\'Heap memory\''
+            ' usageInit=\'2621440\' usageCommitted=\'2621440\''
+            ' usageMax=\'2621440\' usageUsed=\'2621440\'/>'
+            '<memorypool name=\'Code Cache\' type=\'Non-heap memory\''
+            ' usageInit=\'2555904\' usageCommitted=\'6225920\''
+            ' usageMax=\'251658240\' usageUsed=\'6211200\'/>'
+            '<memorypool name=\'Compressed Class Space\''
+            ' type=\'Non-heap memory\' usageInit=\'0\''
+            ' usageCommitted=\'2097152\' usageMax=\'1073741824\''
+            ' usageUsed=\'1959616\'/>'
+            '<memorypool name=\'Metaspace\' type=\'Non-heap memory\''
+            ' usageInit=\'0\' usageCommitted=\'18874368\''
+            ' usageMax=\'-1\' usageUsed=\'18211520\'/>'
+            '</jvm>'
+            '<connector name="ajp-nio-8009">'
+            '<threadInfo  maxThreads="200" currentThreadCount="0"'
+            ' currentThreadsBusy="0" />'
+            '<requestInfo  maxTime="0" processingTime="0" requestCount="0"'
+            ' errorCount="0" bytesReceived="0" bytesSent="0" />'
+            '<workers></workers>'
+            '</connector>'
+            '<connector name="http-nio-8080"><threadInfo  maxThreads="200"'
+            ' currentThreadCount="2" currentThreadsBusy="1" />'
+            '<requestInfo  maxTime="60" processingTime="60"'
+            ' requestCount="1" errorCount="1"'
+            ' bytesReceived="0" bytesSent="2473" />'
+            '<workers><worker  stage="S" requestProcessingTime="52"'
+            ' requestBytesSent="0" requestBytesReceived="0"'
+            ' remoteAddr="0:0:0:0:0:0:0:1" virtualHost="localhost"'
+            ' method="GET" currentUri="/manager/status"'
+            ' currentQueryString="XML=true" protocol="HTTP/1.1" />'
+            '</workers>'
+            '</connector>'
+            '</status>'
+            )
+
+
+class MockedURLResponse(object):
+    def read(self):
+        return server_status_value()
+
+
+class MockedTomcatContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'tomcat'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = [8080, 443]
+        return ports
+
+
+class MockedNoPortContainer(object):
+
+    def __init__(
+            self,
+            container_id,
+    ):
+        self.image_name = 'tomcat'
+
+    def get_container_ip(self):
+        return '1.2.3.4'
+
+    def get_container_ports(self):
+        ports = []
+        return ports
+
+
+class MockedNoNameContainer(object):
+
+    def __init__(self, container_id):
+        self.image_name = 'dummy'
+
+
+class TomcatCrawlTests(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_hundle_ioerror(self):
+        with self.assertRaises(CrawlError):
+            tomcat_crawler.retrieve_status_page("localhost",
+                                                "1234", "test", "test")
+
+    @mock.patch('urllib2.urlopen', mocked_urllib2_open)
+    def test_ok(self):
+        status = list(tomcat_crawler.retrieve_metrics())
+        assert status == [('tomcat_jvm',
+                           feature.TomcatJVMFeature(
+                               free='3846720',
+                               total='62390272',
+                               max='922746880'),
+                           'application'),
+                          ('tomcat_memory',
+                           feature.TomcatMemoryFeature(
+                               name='PS Eden Space',
+                               type='Heap memory',
+                               initial='16252928',
+                               committed='16252928',
+                               maximum='340787200',
+                               used='8570016'),
+                           'application'),
+                          ('tomcat_memory',
+                           feature.TomcatMemoryFeature(
+                               name='PS Survivor Space',
+                               type='Heap memory',
+                               initial='2621440',
+                               committed='2621440',
+                               maximum='2621440',
+                               used='2621440'),
+                           'application'),
+                          ('tomcat_memory',
+                           feature.TomcatMemoryFeature(
+                               name='Code Cache',
+                               type='Non-heap memory',
+                               initial='2555904',
+                               committed='6225920',
+                               maximum='251658240',
+                               used='6211200'),
+                           'application'),
+                          ('tomcat_memory',
+                           feature.TomcatMemoryFeature(
+                               name='Compressed Class Space',
+                               type='Non-heap memory',
+                               initial='0',
+                               committed='2097152',
+                               maximum='1073741824',
+                               used='1959616'),
+                           'application'),
+                          ('tomcat_memory',
+                           feature.TomcatMemoryFeature(
+                               name='Metaspace',
+                               type='Non-heap memory',
+                               initial='0',
+                               committed='18874368',
+                               maximum='-1',
+                               used='18211520'),
+                           'application'),
+                          ('tomcat_connector',
+                           feature.TomcatConnectorFeature(
+                               connector='ajp-nio-8009',
+                               maxThread='200',
+                               currentThread='0',
+                               currentThreadBusy='0',
+                               requestMaxTime='0',
+                               processingTime='0',
+                               requestCount='0',
+                               errorCount='0',
+                               byteReceived='0',
+                               byteSent='0'),
+                           'application'),
+                          ('tomcat_connector',
+                           feature.TomcatConnectorFeature(
+                               connector='http-nio-8080',
+                               maxThread='200',
+                               currentThread='2',
+                               currentThreadBusy='1',
+                               requestMaxTime='60',
+                               processingTime='60',
+                               requestCount='1',
+                               errorCount='1',
+                               byteReceived='0',
+                               byteSent='2473'),
+                           'application'),
+                          ('tomcat_worker',
+                           feature.TomcatWorkerFeature(
+                               connector='http-nio-8080',
+                               stage='S',
+                               time='52',
+                               byteSent='0',
+                               byteReceived='0',
+                               client='0:0:0:0:0:0:0:1',
+                               vhost='localhost',
+                               request='/manager/status'),
+                           'application')]
+
+
+class TomcatHostTest(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = TomcatHostCrawler()
+        self.assertEqual(c.get_feature(), 'tomcat')
+
+    @mock.patch('plugins.applications.tomcat.'
+                'tomcat_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    def test_get_metrics(self):
+        c = TomcatHostCrawler()
+        options = {"password": "password", "user": "tomcat"}
+        emitted = list(c.crawl(**options))
+        self.assertEqual(emitted[0][0], 'tomcat_jvm')
+        self.assertEqual(emitted[0][2], 'application')
+
+
+class TomcatContainerTest(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_feature(self):
+        c = TomcatContainerCrawler()
+        self.assertEqual(c.get_feature(), 'tomcat')
+
+    @mock.patch('plugins.applications.tomcat.'
+                'tomcat_crawler.retrieve_status_page',
+                mocked_retrieve_status_page)
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedTomcatContainer)
+    def test_get_metrics(self):
+        c = TomcatContainerCrawler()
+        options = {"password": "password", "user": "tomcat"}
+        emitted = list(c.crawl(**options))
+        self.assertEqual(emitted[0][0], 'tomcat_jvm')
+        self.assertEqual(emitted[0][2], 'application')
+
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedNoPortContainer)
+    def test_no_available_port(self):
+        c = TomcatContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")
+
+    @mock.patch('dockercontainer.DockerContainer',
+                MockedNoNameContainer)
+    def test_none_tomcat_container(self):
+        c = TomcatContainerCrawler()
+        with self.assertRaises(CrawlError):
+            c.crawl("mockcontainer")


### PR DESCRIPTION
This PR supports to gather tomcat server metrics.
The detail information is described at issue #196 

This plugin gathers server status metric of tomcat as follows.
```
application	"tomcat_jvm"	{"free":"76526408","total":"120061952","max":"1390936064"}
application	"tomcat_memory"	{"name":"PS Eden Space","type":"Heap memory",...,"used":"30755648"}
application	"tomcat_memory"	{"name":"PS Old Gen","type":"Heap memory",...,"used":"9136520"}
```