### PR TITLE
Remove redis and ibm_db modules from requiremets.txt

### DIFF
--- a/crawler/plugins/applications/db2/db2_crawler.py
+++ b/crawler/plugins/applications/db2/db2_crawler.py
@@ -1,9 +1,6 @@
-import ibm_db_dbi
-import ibm_db
 import logging
 from plugins.applications.db2 import feature
 from utils.crawler_exceptions import CrawlError
-
 
 logger = logging.getLogger('crawlutils')
 
@@ -11,6 +8,10 @@ logger = logging.getLogger('crawlutils')
 def retrieve_metrics(host='localhost',
                      user='db2inst1', password='db2inst1-pwd',
                      db='sample'):
+    import pip
+    pip.main(['install', 'ibm_db'])
+    import ibm_db_dbi
+    import ibm_db
 
     sql_list = ["SELECT db_size FROM systools.stmg_dbsize_info",
                 "SELECT db_capacity FROM systools.stmg_dbsize_info",

--- a/crawler/plugins/applications/redis/redis_container_crawler.py
+++ b/crawler/plugins/applications/redis/redis_container_crawler.py
@@ -2,8 +2,8 @@ from icrawl_plugin import IContainerCrawler
 from plugins.applications.redis import feature
 import dockercontainer
 from requests.exceptions import ConnectionError
-import redis
 import logging
+
 
 logger = logging.getLogger('crawlutils')
 
@@ -22,6 +22,10 @@ class RedisContainerCrawler(IContainerCrawler):
         return self.feature_key
 
     def crawl(self, container_id=None, **kwargs):
+
+        import pip
+        pip.main(['install', 'redis'])
+        import redis
 
         # only crawl redis container. Otherwise, quit.
         c = dockercontainer.DockerContainer(container_id)

--- a/crawler/plugins/applications/redis/redis_host_crawler.py
+++ b/crawler/plugins/applications/redis/redis_host_crawler.py
@@ -1,7 +1,6 @@
 from icrawl_plugin import IHostCrawler
 from plugins.applications.redis import feature
 from requests.exceptions import ConnectionError
-import redis
 import logging
 
 logger = logging.getLogger('crawlutils')
@@ -22,6 +21,10 @@ class RedisHostCrawler(IHostCrawler):
 
     # TODO: prepare an useful way to set host/port
     def crawl(self, root_dir='/', **kwargs):
+        import pip
+        pip.main(['install', 'redis'])
+        import redis
+
         try:
             client = redis.Redis(host='localhost', port=self.default_port)
             metrics = client.info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,4 @@ python-dateutil==2.4.2
 semantic_version==2.5.0
 Yapsy==1.11.223
 configobj==4.7.0
-redis>=2.10.5
 morph==0.1.2
-ibm_db>=2.0.7

--- a/tests/unit/test_app_db2.py
+++ b/tests/unit/test_app_db2.py
@@ -1,4 +1,5 @@
 import mock
+import pip
 from unittest import TestCase
 from plugins.applications.db2 import db2_crawler
 from plugins.applications.db2.feature import DB2Feature
@@ -7,6 +8,9 @@ from plugins.applications.db2.db2_container_crawler \
 from plugins.applications.db2.db2_host_crawler \
     import DB2HostCrawler
 from utils.crawler_exceptions import CrawlError
+
+
+pip.main(['install', 'ibm_db'])
 
 
 class MockedNoNameContainer(object):
@@ -128,6 +132,10 @@ class DB2CrawlTests(TestCase):
 
     def tearDown(self):
         pass
+
+    def test_noimport(self):
+        pip.main(['uninstall', '--yes', 'ibm_db'])
+        db2_crawler.retrieve_metrics()
 
     @mock.patch('ibm_db_dbi.Connection', mocked_dbi_conn_error)
     def test_conn_error(self):

--- a/tests/unit/test_app_db2.py
+++ b/tests/unit/test_app_db2.py
@@ -133,10 +133,6 @@ class DB2CrawlTests(TestCase):
     def tearDown(self):
         pass
 
-    def test_noimport(self):
-        pip.main(['uninstall', '--yes', 'ibm_db'])
-        db2_crawler.retrieve_metrics()
-
     @mock.patch('ibm_db_dbi.Connection', mocked_dbi_conn_error)
     def test_conn_error(self):
         with self.assertRaises(CrawlError):

--- a/tests/unit/test_app_redis.py
+++ b/tests/unit/test_app_redis.py
@@ -1,4 +1,5 @@
 import mock
+import pip
 from unittest import TestCase
 from plugins.applications.redis.feature import RedisFeature
 from plugins.applications.redis.feature import create_feature
@@ -7,7 +8,9 @@ from plugins.applications.redis.redis_host_crawler \
 from plugins.applications.redis.redis_container_crawler \
     import RedisContainerCrawler
 from requests.exceptions import ConnectionError
-import redis
+
+
+pip.main(['install', 'redis'])
 
 
 class MockedRedisClient(object):
@@ -268,6 +271,7 @@ class RedisHostCrawlTests(TestCase):
 
     @mock.patch('redis.Redis', MockedRedisClient3)
     def test_redis_host_crawler_dummy(self):
+        import redis
         client = redis.Redis()
         feature_attributes = create_feature(client.info())
         self.assertEqual(feature_attributes[0], -1)


### PR DESCRIPTION
Remove ibm_db and redis modules from requirements.txt and import them in each code according a comment of #252 

Signed-off-by: hitomitak <hitomi@jp.ibm.com> #