### PR TITLE
fix issue 276

### DIFF
--- a/tests/functional/test_functional_logs_linker.py
+++ b/tests/functional/test_functional_logs_linker.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sys
 import subprocess
+import plugins_manager
 
 from containers_logs_linker import DockerContainersLogsLinker
 from worker import Worker
@@ -24,6 +25,7 @@ class LogsLinkerTests(unittest.TestCase):
             '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
         ch.setFormatter(formatter)
         root.addHandler(ch)
+        plugins_manager.runtime_env = None
         self.container = {}
         self.container_name = 'LogLinkerContainer'
         self.host_namespace = get_host_ipaddr()


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

This PR contains fix for issue #276.
  1) K8S environment plugin now parsed and creates a crawler namespace for standard k8s deployment in the form of 
`<namespace>/<pod-name>/<container-name>/<container-id>`

2) functional test case is updated to test these new namespace for different emitter formats.