### PR TITLE
Adjust fprobe command line parameters

### DIFF
--- a/crawler/plugins/systems/fprobe_container_crawler.py
+++ b/crawler/plugins/systems/fprobe_container_crawler.py
@@ -138,7 +138,10 @@ class FprobeContainerCrawler(IContainerCrawler):
                   '-i', ifname,
                   '-u', user,
                   '-n', '%d' % netflow_version,
-                  '-fip',
+                  # '-fip', doesn't work well
+                  '-S', '6400',
+                  '-B', '256',
+                  '-p',
                   '-l', '2',
                   '-e', '%d' % lifetime_timeout,
                   '-d', '%d' % idle_timeout,


### PR DESCRIPTION
To improve precision at high throughput rates add the snaplen
and kernel buffer size parameters.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>