### PR TITLE
Switch from fprobe to softflowd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /crawler
 COPY requirements.txt /crawler/requirements.txt
 RUN pip install -r requirements.txt
 
-ADD crawler /crawler
-
 COPY dependencies/python-socket-datacollector_0.1.1-1_all.deb /tmp
 RUN dpkg -i /tmp/python-socket-datacollector_*_all.deb && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install fprobe
+    DEBIAN_FRONTEND=noninteractive apt-get -y install softflowd
+
+ADD crawler /crawler
 
 ENTRYPOINT [ "python2.7", "crawler.py" ]

--- a/crawler/crawler.conf
+++ b/crawler/crawler.conf
@@ -22,27 +22,26 @@
     avoid_setns = False
 
     [[ fprobe_container ]]
-    # parameters for fprobe timeouts
-    idle_timeout = 5
-    lifetime_timeout = 5
+    # parameters for softflowd timeouts
+    maxlife_timeout = 10
 
-    # fprobe must create netflow version 5
+    # flow probe must create netflow version 5
     netflow_version = 5
 
-    # The directory where all the fprobe output data will be written to
+    # The directory where all the flow probe's output data will be written to
     fprobe_output_dir = /tmp/crawler-fprobe
 
     # The filename pattern of the files that the data collector will produce
     # container-id, pid, and timestamp will be replaced with concrete values
     output_filepattern = fprobe-{ifname}-{timestamp}
 
-    # The use to switch fprobe and socket-datafile collector to in order to
+    # The user to switch socket-datafile collector to in order to
     # drop root privileges
     fprobe_user = nobody
 
-    # Terminate the started fprobe process when terminating the crawler;
+    # Terminate the started netflow probe process when terminating the crawler;
     # this is useful when running the crawler as a process and all started
-    # fprobe processes should automatically terminate, thus ending to produce
-    # fruther data; set to 'false' or '0' to disable, enable otherwise;
+    # flow probe processes should automatically terminate, thus ending to
+    # produce further data; set to 'false' or '0' to disable, enable otherwise;
     # the default value is 'false'
     terminate_fprobe = 1

--- a/tests/functional/test_functional_fprobe.py
+++ b/tests/functional/test_functional_fprobe.py
@@ -61,7 +61,7 @@ def mocked_start_child(params, pass_fds, null_fds, ign_sigs, setsid=False,
 
 def mocked_start_child_fprobe_fail(params, pass_fds, null_fds, ign_sigs,
                                    setsid=False, **kwargs):
-    if params[0] == 'fprobe':
+    if params[0] == 'softflowd':
         return start_child(['___no_such_file'], pass_fds, null_fds, ign_sigs,
                            setsid, **kwargs)
     return start_child(['sleep', '1'], pass_fds, null_fds, ign_sigs, setsid,
@@ -89,7 +89,7 @@ def mocked_psutil_process_iter():
 
         def cmdline(self):
             return self._cmdline
-    yield MyProcess('fprobe', ['-i', 'test.eth0', '127.0.0.1:1234'], 11111)
+    yield MyProcess('softflowd', ['-i', 'test.eth0', '127.0.0.1:1234'], 11111)
 
 
 # Tests conducted with a single container running.
@@ -224,7 +224,7 @@ class FprobeFunctionalTests(unittest.TestCase):
                 mocked_psutil_process_iter)
     def test_interfaces_with_fprobes(self):
         logger = logging.getLogger("crawlutils")
-        logger.info('>>> Testcase: determine interfaces on which fprobes '
+        logger.info('>>> Testcase: determine interfaces on which flow probes '
                     'are running')
         s = FprobeContainerCrawler.interfaces_with_fprobes()
         assert 'test.eth0' in s.keys()


### PR DESCRIPTION
Softflowd seems to be the more reliable tool compared to fprobe.
Use softflowd now as a more or less straight replacement. Change
some of the comments in the code to not reflect the tool fprobe
anymore but either refer to a 'flow probe' or 'softflowd' if it's
about the program name.

Only use one timeout parameter for softflowd, the 'maxlife' timeout
parameter that expires all flows after a few seconds. This avoids
having to provide at least 6 individual parmeters for controlling
timeouts for TCP, UDP, etc. Since softflowd produces netflow V{1,5,9},
we need to adjust this as well from fprobe's V{1,5,7}.

Address some pylint complaints about import order.

Make the building of the container more efficient by reversing the
order of commands.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>