### PR TITLE
fprobe: Add Berkley Packet Filter (BPF) parameter to config file

### DIFF
--- a/crawler/crawler.conf
+++ b/crawler/crawler.conf
@@ -46,6 +46,9 @@
     # the default value is 'false'
     terminate_fprobe = 1
 
+    # Berkel packet filter for the probe
+    fprobe_bpf = (tcp[tcpflags] & (tcp-syn|tcp-ack|tcp-fin) != 0) or not tcp
+
 [ emitters ]
 
     [[ Stdout Emitter ]]

--- a/crawler/plugins/systems/fprobe_container_crawler.py
+++ b/crawler/plugins/systems/fprobe_container_crawler.py
@@ -135,6 +135,7 @@ class FprobeContainerCrawler(IContainerCrawler):
 
         terminate_process = kwargs.get('terminate_fprobe', 'FALSE').upper()
         setsid = terminate_process in ['0', 'FALSE']
+        fprobe_bpf = kwargs.get('fprobe_bpf', '')
 
         params = ['softflowd',
                   '-i', ifname,
@@ -142,6 +143,8 @@ class FprobeContainerCrawler(IContainerCrawler):
                   '-d',
                   '-t', 'maxlife=%d' % maxlife_timeout,
                   '-n', '%s:%d' % (bindaddr, port)]
+        if len(fprobe_bpf.strip()):
+            params.append(fprobe_bpf)
         try:
             pid, errcode = start_child(params, [], [0, 1, 2],
                                        [signal.SIGCHLD],


### PR DESCRIPTION
To provde the possibility to lower the CPU consumption of the flow probe
we add an fprobe_bpf parameter to the config file that allows a user
to set a BPF. The example BPF drives down the CPU consumption to nearly
0% at the expense of only reporting TCP connection information without
providing volumetric data (packet and byte counts). All other protocols
should be left untouched by this example BPF.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>