### PR TITLE
utils: wait for child to _exit()

### DIFF
--- a/crawler/utils/process_utils.py
+++ b/crawler/utils/process_utils.py
@@ -118,5 +118,7 @@ def start_child(params, pass_fds, null_fds, ign_sigs, setsid=False,
         except:
             pid = -1
         os.close(rfd)
+        # wait for child process to _exit()
+        os.waitpid(-1, 0)
 
         return pid, errcode


### PR DESCRIPTION
To avoid python zombie processes wait for the child to _exit().

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>