### PR TITLE
Add ssl verify on/off option to sas emitter

### DIFF
--- a/crawler/crawler.conf
+++ b/crawler/crawler.conf
@@ -64,3 +64,4 @@
     token_filepath = /etc/sas-secrets/token
     access_group_filepath = /etc/sas-secrets/access_group
     cloudoe_filepath = /etc/sas-secrets/cloudoe
+    ssl_verification = False

--- a/crawler/plugins/emitters/sas_emitter.plugin
+++ b/crawler/plugins/emitters/sas_emitter.plugin
@@ -11,3 +11,4 @@ Description = Plugin to post frame data to SAS (security analytics service) http
 token_filepath = /etc/sas-secrets/token
 access_group_filepath = /etc/sas-secrets/access_group
 cloudoe_filepath = /etc/sas-secrets/cloudoe
+ssl_verifcation = False

--- a/crawler/plugins/emitters/sas_emitter.py
+++ b/crawler/plugins/emitters/sas_emitter.py
@@ -38,6 +38,7 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
         self.token_filepath = kwargs.get("token_filepath", "")
         self.access_group_filepath = kwargs.get("access_group_filepath", "")
         self.cloudoe_filepath = kwargs.get("cloudoe_filepath", "")
+        self.ssl_verification = kwargs.get("ssl_verification", "")
 
         iostream = self.format(frame)
         if compress:
@@ -113,11 +114,15 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
 
         self.url = self.url.replace('sas:', 'https:')
 
+        verify = True
+        if self.ssl_verification == "False":
+            verify = False
+
         for attempt in range(self.max_retries):
             try:
                 response = requests.post(self.url, headers=headers,
                                          params=params,
-                                         data=content)
+                                         data=content, verify=verify)
             except requests.exceptions.ChunkedEncodingError as e:
                 logger.exception(e)
                 logger.error(


### PR DESCRIPTION
Signed-off-by: Hitomi Takahashi <hitomi@jp.ibm.com>

As I mentioned #279, I added the new option to switch on/off SSL verification in sas emitter plugin. 
When add the following option to "SAS HTTPS Emitter" section in crawler.conf, SSL verify is skipped in requests.post function. (Default is True)
```
ssl_verification = False
```
