### PR TITLE
remove \r from graphite feature format

### DIFF
--- a/crawler/emitter.py
+++ b/crawler/emitter.py
@@ -185,7 +185,7 @@ class Emitter:
                 suffix = 'load.load'
             suffix = suffix.replace('/', '$')
 
-            tmp_message = '%s.%s.%s %f %d\r\n' % (sysname, suffix,
+            tmp_message = '%s.%s.%s %f %d\n' % (sysname, suffix,
                                                   metric, value, timestamp)
             self.emitfile.write(tmp_message)
 


### PR DESCRIPTION
Removed '\r' in the Watson WDC version of agentless crawler for emitter.py to mtgraphite