### PR TITLE
 Define unicode for Python 3

### DIFF
--- a/crawler/plugins/environments/cloudsight_environment.py
+++ b/crawler/plugins/environments/cloudsight_environment.py
@@ -1,11 +1,16 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import logging
 import copy
+import logging
+import os
 
 from runtime_environment import IRuntimeEnvironment
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 logger = logging.getLogger('crawlutils')
 
@@ -17,15 +22,13 @@ class CloudsightEnvironment(IRuntimeEnvironment):
         return self.name
 
     def get_container_namespace(self, long_id, options):
-        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        assert isinstance(long_id, (str, unicode)), "long_id is not a string"
         assert 'name' in options and 'host_namespace' in options
-        name = options['name']
-        name = (name if len(name) > 0 else long_id[:12])
-        name = (name[1:] if name[0] == '/' else name)
+        name = (options['name'] or long_id[:12]).lstrip('/')
         return options['host_namespace'] + '/' + name
 
     def get_container_log_file_list(self, long_id, options):
-        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        assert isinstance(long_id, (str, unicode)), "long_id is not a string"
         assert 'container_logs' in options
         container_logs = copy.deepcopy(options['container_logs'])
         for log in container_logs:
@@ -38,5 +41,5 @@ class CloudsightEnvironment(IRuntimeEnvironment):
         return container_logs
 
     def get_container_log_prefix(self, long_id, options):
-        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        assert isinstance(long_id, (str, unicode)), "long_id is not a string"
         return self.get_container_namespace(long_id, options)


### PR DESCRIPTION
Replaces #320

Also:
* avoid hard coding path to Python
* simplified `name` determination
* fixed isinstance() tests

Signed-off-by: Chris Clauss cclauss@bluewin.ch