### PR TITLE
Add modifiable source_type support to sas emitter

### DIFF
--- a/crawler/plugins/emitters/sas_emitter.py
+++ b/crawler/plugins/emitters/sas_emitter.py
@@ -110,7 +110,16 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
         params.update({'namespace': namespace})
         params.update({'features': features})
         params.update({'timestamp': timestamp})
-        params.update({'source_type': system_type})
+
+        # load source_type from env variables
+        # if not set, it uses system_type as a default value
+        # live crawler should be set it as 'container' and
+        # reg crawler should be set it as 'image'
+        if 'SOURCE_TYPE' in os.environ:
+            source_type = os.environ['SOURCE_TYPE']
+            params.update({'source_type': source_type})
+        else:
+            params.update({'source_type': system_type})
 
         self.url = self.url.replace('sas:', 'https:')
 


### PR DESCRIPTION
Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>

This PR is related to #329. 
In order to load `source_type` value for registry crawler, I prepared an additional `env` variables for sas emitter. Available variables are `SOURCE_TYPE=container` or `SOURCE_TYPE=image`. The default value is `container`, so sas-emitter plugin automatically uses `container` as `SOURCE_TYPE`. 