### PR TITLE
Implemented a diskio host plugin to crawl disk-bandwidth usage

### DIFF
--- a/crawler/plugins/systems/diskio_host_crawler.plugin
+++ b/crawler/plugins/systems/diskio_host_crawler.plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = diskio_host
+Module = diskio_host_crawler
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = "Disk I/O crawling function for hosts"

--- a/crawler/plugins/systems/diskio_host_crawler.py
+++ b/crawler/plugins/systems/diskio_host_crawler.py
@@ -1,0 +1,96 @@
+import logging
+import time
+import psutil
+
+from icrawl_plugin import IHostCrawler
+from utils.features import DiskioFeature
+
+logger = logging.getLogger('crawlutils')
+
+
+class DiskioHostCrawler(IHostCrawler):
+    '''
+    Plugin for crawling disk I/O counters from host and
+    computing the bytes/second rate for read and write operations
+    '''
+
+    def __init__(self):
+        self._cached_values = {}
+        self._previous_rates = {}
+
+    def _cache_put_value(self, key, value):
+        self._cached_values[key] = (value, time.time())
+
+    def _cache_get_value(self, key):
+        if key in self._cached_values:
+            return self._cached_values[key]
+        else:
+            return None, None
+
+    def _crawl_disk_io_counters(self):
+        try:
+            disk_counters = psutil.disk_io_counters(perdisk=True)
+            for device_name in disk_counters:
+                counters = disk_counters[device_name]
+                curr_counters = [
+                    counters.read_count,
+                    counters.write_count,
+                    counters.read_bytes,
+                    counters.write_bytes
+                ]
+                logger.debug(
+                    u'Disk I/O counters - {0}: {1}'.format(device_name,
+                                                           curr_counters))
+                yield (device_name, curr_counters)
+        except OSError as e:
+            logger.debug(
+                u'Caught exception when crawling disk I/O counters: {0}'.
+                format(e))
+
+    def crawl(self, **kwargs):
+        logger.debug('Crawling %s' % self.get_feature())
+        diskio_data = self._crawl_disk_io_counters()
+        for device_name, curr_counters in diskio_data:
+            logger.debug(u'Processing device {0}; counters = {1}'.
+                         format(device_name, curr_counters))
+
+            feature_key = '{0}-{1}'.format('diskio', device_name)
+            cache_key = '{0}-{1}'.format('INVM', feature_key)
+            (prev_counters, prev_time) = self._cache_get_value(cache_key)
+            self._cache_put_value(cache_key, curr_counters)
+
+            if prev_counters and prev_time:
+                # Compute the rates (per second) for each attribute, namely:
+                #   read_op/s, write_op/s, read_bytes/s, and write_bytes/s
+                time_diff = time.time() - prev_time
+                rates = [
+                    round(
+                        (a - b) / time_diff,
+                        2) for (
+                        a,
+                        b) in zip(
+                        curr_counters,
+                        prev_counters)]
+                for i in range(len(rates)):
+                    if rates[i] < 0:
+                        # The corresponding OS counter has wrapped
+                        # For now, let's return the previous measurement
+                        # to avoid a huge drop on the metric graph
+                        rates[i] = self._previous_rates[device_name][i]
+                        logger.debug(
+                            u'Counter "{0}" for device {1} has wrapped'.
+                            format(i, device_name))
+            else:
+                # first measurement
+                rates = [0] * 4
+
+            self._previous_rates[device_name] = rates
+            logger.debug(
+                u'Disk I/O counters rates- {0}: {1}'.format(device_name,
+                                                            rates))
+
+            diskio_feature_attributes = DiskioFeature._make(rates)
+            yield(feature_key, diskio_feature_attributes, 'diskio')
+
+    def get_feature(self):
+        return 'diskio'

--- a/crawler/utils/features.py
+++ b/crawler/utils/features.py
@@ -33,6 +33,12 @@ DiskFeature = namedtuple('DiskFeature', [
     'mountopts',
     'partitionsize',
 ])
+DiskioFeature = namedtuple('DiskioFeature', [
+    'readoprate',
+    'writeoprate',
+    'readbytesrate',
+    'writebytesrate',
+])
 ProcessFeature = namedtuple('ProcessFeature', [
     'cmd',
     'created',

--- a/tests/unit/test_diskio_host.py
+++ b/tests/unit/test_diskio_host.py
@@ -1,0 +1,130 @@
+'''
+Unit tests for the DiskioHostCrawler plugin
+'''
+import unittest
+import mock
+
+from plugins.systems.diskio_host_crawler import DiskioHostCrawler
+
+counters_increment = 0
+time_increment = 0
+
+def mocked_time():
+    '''
+    Used to mock time.time(), which the crawler calls to calculate rates
+    '''
+    global time_increment
+
+    base_time = 1504726245
+    return base_time + time_increment
+
+def mocked_diskio_counters():
+    '''
+    Used to mock DiskContainerCrawler._crawl_disk_io_counters()
+    '''
+    global counters_increment
+
+    base_counters = [10, 10, 10, 10]
+    counters = [ i + counters_increment for i in base_counters]
+    yield ('loop', [0, 0 , 0, 0])
+    yield ('sda1', counters)
+
+class TestDiskioCrawlerPlugin(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._crawler = DiskioHostCrawler()
+
+    def testGetFeature(self):
+        crawler = DiskioHostCrawler()
+        self.assertEqual('diskio', crawler.get_feature())
+
+    def test_crawl_disk_io_counters(self):
+        crawler = DiskioHostCrawler()
+        diskio_data = crawler._crawl_disk_io_counters()
+        for device_name, counters in diskio_data:
+            self.assertIsInstance(device_name, basestring)
+            self.assertEqual(4, len(counters))
+            for counter in counters:
+                self.assertIsInstance(counter, (int, long))
+
+    @mock.patch('time.time', side_effect=mocked_time)
+    @mock.patch.object(DiskioHostCrawler, '_crawl_disk_io_counters', side_effect=mocked_diskio_counters)
+    def testCrawl(self, mocked_diskio_counters, mocked_time):
+        global counters_increment
+        global time_increment
+
+        # First crawl
+        diskio_feature = self._crawler.crawl()
+        for device_name, feature_attributes, feature_key in diskio_feature:
+            self.assertEqual('diskio', feature_key)
+            self.assertEqual(4, len(feature_attributes), 'Incorrect number of attributes')
+            self.assertIsInstance(device_name, basestring, 'Device name should be string')
+
+            self.assertEqual(0, feature_attributes.readoprate, 'Unexpected read operations per second')
+            self.assertEqual(0, feature_attributes.writeoprate, 'Unexpected write operations per second')
+            self.assertEqual(0, feature_attributes.readbytesrate, 'Unexpected bytes read per second')
+            self.assertEqual(0, feature_attributes.writebytesrate, 'Unexpected bytes written per second')
+
+            if device_name == 'diskio-loop':
+                pass
+            elif device_name == 'diskio-sda1':
+                pass
+            else:
+                raise Exception('Unexpected device name')
+
+        # Make sure counters will be incremented by mock the function mocking I/O counters
+        counters_increment = 100.0
+
+        # Make sure the time will be incremented by the mocked time.time()
+        time_increment = 60
+
+        # Second crawl
+        diskio_feature = self._crawler.crawl()
+        for device_name, feature_attributes, feature_key in diskio_feature:
+            self.assertEqual('diskio', feature_key)
+            self.assertEqual(4, len(feature_attributes), 'Incorrect number of attributes')
+            self.assertIsInstance(device_name, basestring, 'Device name should be string')
+            if device_name == 'diskio-loop':
+                self.assertEqual(0, feature_attributes.readoprate, 'Unexpected read operations per second')
+                self.assertEqual(0, feature_attributes.writeoprate, 'Unexpected write operations per second')
+                self.assertEqual(0, feature_attributes.readbytesrate, 'Unexpected bytes read per second')
+                self.assertEqual(0, feature_attributes.writebytesrate, 'Unexpected bytes written per second')
+            elif device_name == 'diskio-sda1':
+                expected_rate = round(counters_increment/time_increment, 2)
+                self.assertEqual(feature_attributes.readoprate, expected_rate, 'Unexpected read operations per second')
+                self.assertEqual(feature_attributes.writeoprate, expected_rate, 'Unexpected write operations per second')
+                self.assertEqual(feature_attributes.readbytesrate, expected_rate, 'Unexpected bytes read per second')
+                self.assertEqual(feature_attributes.writebytesrate, expected_rate, 'Unexpected bytes written per second')
+            else:
+                raise Exception('Unexpected device name')
+
+        # Make sure the counter-diff as compared to the previous crawl will be negative,
+        # to emulate a case where the OS counters have wrapped
+        # In this case, the crawler is expected to report the same measurement as before  
+        counters_increment = -500.0
+
+        # Make sure the time will be incremented by the mocked time.time()
+        time_increment += 60
+
+        # Third crawl
+        diskio_feature = self._crawler.crawl()        
+        for device_name, feature_attributes, feature_key in diskio_feature:
+            self.assertEqual('diskio', feature_key)
+            self.assertEqual(4, len(feature_attributes), 'Incorrect number of attributes')
+            self.assertIsInstance(device_name, basestring, 'Device name should be string')
+            if device_name == 'diskio-loop':
+                self.assertEqual(0, feature_attributes.readoprate, 'Unexpected read operations per second')
+                self.assertEqual(0, feature_attributes.writeoprate, 'Unexpected write operations per second')
+                self.assertEqual(0, feature_attributes.readbytesrate, 'Unexpected bytes read per second')
+                self.assertEqual(0, feature_attributes.writebytesrate, 'Unexpected bytes written per second')
+            elif device_name == 'diskio-sda1':
+                self.assertEqual(feature_attributes.readoprate, expected_rate, 'Unexpected read operations per second')
+                self.assertEqual(feature_attributes.writeoprate, expected_rate, 'Unexpected write operations per second')
+                self.assertEqual(feature_attributes.readbytesrate, expected_rate, 'Unexpected bytes read per second')
+                self.assertEqual(feature_attributes.writebytesrate, expected_rate, 'Unexpected bytes written per second')
+            else:
+                raise Exception('Unexpected device name')
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new feature type, named `diskio`, and the corresponding diskio host crawler plugin. This plugin measures, for each disk on the host, the following 4 quantities: reads/s, writes/s, bytes_read/s, and bytes_written/s. The rates are calculated by the plugin.

This PR also includes comprehensive unit tests mocking time.time() and the I/O counters.