### PR TITLE
namespace fix for host crawler

### DIFF
--- a/crawler/host_crawler.py
+++ b/crawler/host_crawler.py
@@ -1,6 +1,6 @@
 import plugins_manager
 from base_crawler import BaseCrawler, BaseFrame
-
+from utils import misc
 
 class HostFrame(BaseFrame):
 
@@ -23,7 +23,12 @@ class HostCrawler(BaseCrawler):
             features, plugin_places, options)
         self.plugins = plugins_manager.get_host_crawl_plugins(
             features=features)
-        self.namespace = namespace
+        hostip = misc.get_host_ipaddr()
+        if hostip != namespace:
+           self.namespace = "{}.{}".format(namespace, hostip)
+        else:
+	   self.namespace = namespace
+
 
     def crawl(self, ignore_plugin_exception=True):
         """

--- a/tests/unit/test_host_crawler.py
+++ b/tests/unit/test_host_crawler.py
@@ -31,7 +31,8 @@ class HostCrawlerTests(unittest.TestCase):
         crawler = HostCrawler(features=['os', 'cpu'], namespace='localhost')
         frames = list(crawler.crawl())
         namespaces = [f.metadata['namespace'] for f in frames]
-        assert namespaces == ['localhost']
+        for namespace in namespaces:
+            assert 'localhost' in namespace
         features_count = [f.num_features for f in frames]
         assert features_count == [2]
         system_types = [f.metadata['system_type'] for f in frames]
@@ -62,7 +63,8 @@ class HostCrawlerTests(unittest.TestCase):
             namespace='localhost')
         frames = list(crawler.crawl())
         namespaces = sorted([f.metadata['namespace'] for f in frames])
-        assert namespaces == sorted(['localhost'])
+        for namespace in namespaces:
+            assert 'localhost' in namespace
         features_count = [f.num_features for f in frames]
         assert features_count == [2]
         system_types = [f.metadata['system_type'] for f in frames]


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

When a namespace is given, this fix will prepend that the host-ip for host crawler. 