### PR TITLE
Add a function to get ip address for metrics crawler in k8s environment

### DIFF
--- a/crawler/plugins/applications/apache/apache_container_crawler.py
+++ b/crawler/plugins/applications/apache/apache_container_crawler.py
@@ -1,10 +1,11 @@
+from utils.namespace import run_as_another_namespace
 import logging
-
-
+import json
+import utils.misc
 import dockercontainer
 from icrawl_plugin import IContainerCrawler
 from plugins.applications.apache import apache_crawler
-from utils.crawler_exceptions import CrawlError
+from requests.exceptions import ConnectionError
 
 logger = logging.getLogger('crawlutils')
 
@@ -12,6 +13,7 @@ logger = logging.getLogger('crawlutils')
 class ApacheContainerCrawler(IContainerCrawler):
     feature_type = 'application'
     feature_key = 'apache'
+    default_port = 80
 
     def get_feature(self):
         return self.feature_key
@@ -20,32 +22,44 @@ class ApacheContainerCrawler(IContainerCrawler):
 
         c = dockercontainer.DockerContainer(container_id)
 
-        # check image name
-        if c.image_name.find("httpd") == -1:
+        port = None
 
-            logger.error("%s is not %s container",
-                         c.image_name,
-                         self.feature_key)
-            raise CrawlError("%s does not have expected name for %s (name=%s)",
-                             container_id,
-                             self.feature_key,
-                             c.image_name)
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
 
-        # crawl all candidate ports
-        for port in ports:
-            try:
-                metrics = apache_crawler.retrieve_metrics(ip, port)
-            except CrawlError:
-                logger.error("can't find metrics endpoint at http://%s:%s",
-                             ip,
-                             port)
-                continue
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
+        for each_port in ports:
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
+
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        if not port:
+            return
+
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
+
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
+        try:
+            metrics = apache_crawler.retrieve_metrics(ip, port)
             return [(self.feature_key, metrics, self.feature_type)]
-
-        raise CrawlError("%s has no accessible endpoint for %s",
-                         container_id,
-                         self.feature_key)
+        except:
+            logger.info("apache does not listen on port:%d", port)
+            raise ConnectionError("apache does not listen on port:%d", port)

--- a/crawler/plugins/applications/db2/db2_container_crawler.py
+++ b/crawler/plugins/applications/db2/db2_container_crawler.py
@@ -1,9 +1,11 @@
 import logging
-
 import dockercontainer
 from icrawl_plugin import IContainerCrawler
 from plugins.applications.db2 import db2_crawler
-from utils.crawler_exceptions import CrawlError
+from utils.namespace import run_as_another_namespace
+import json
+import utils.misc
+from requests.exceptions import ConnectionError
 
 logger = logging.getLogger('crawlutils')
 
@@ -11,11 +13,12 @@ logger = logging.getLogger('crawlutils')
 class DB2ContainerCrawler(IContainerCrawler):
     feature_type = 'application'
     feature_key = 'db2'
+    default_port = 50000
 
     def get_feature(self):
         return self.feature_key
 
-    def crawl(self, container_id=None, **kwargs):
+    def get_opt(self, kwargs):
         password = "db2inst1"
         user = "db2inst1-pwd"
         db = "sample"
@@ -29,37 +32,57 @@ class DB2ContainerCrawler(IContainerCrawler):
         if "db" in kwargs:
             db = kwargs["db"]
 
+        return password, user, db
+
+    def crawl(self, container_id=None, **kwargs):
+
+        password, user, db = self.get_opt(kwargs)
         c = dockercontainer.DockerContainer(container_id)
 
-        # check image name
-        if c.image_name.find(self.feature_key) == -1:
-            logger.error("%s is not %s container",
-                         c.image_name,
-                         self.feature_key)
-            raise CrawlError("%s does not have expected name for %s (name=%s)",
-                             container_id,
-                             self.feature_key,
-                             c.image_name)
+        port = None
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
 
-        # crawl all candidate ports
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
+
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
         for each_port in ports:
-            try:
-                metrics = db2_crawler.retrieve_metrics(
-                    host=ip,
-                    user=user,
-                    password=password,
-                    db=db,
-                )
-            except CrawlError:
-                logger.error("can't find metrics endpoint at %s db %s",
-                             ip, db)
-                continue
-            return [(self.feature_key, metrics, self.feature_type)]
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
 
-        raise CrawlError("%s has no accessible endpoint for %s",
-                         container_id,
-                         self.feature_key)
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        if not port:
+            return
+
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
+
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
+
+        try:
+            metrics = db2_crawler.retrieve_metrics(
+                host=ip,
+                user=user,
+                password=password,
+                db=db,
+            )
+            return [(self.feature_key, metrics, self.feature_type)]
+        except:
+            logger.info("db2 does not listen on port:%d", port)
+            raise ConnectionError("db2 does not listen on port:%d", port)

--- a/crawler/plugins/applications/liberty/liberty_container_crawler.py
+++ b/crawler/plugins/applications/liberty/liberty_container_crawler.py
@@ -1,9 +1,11 @@
 import logging
-
 import dockercontainer
 from icrawl_plugin import IContainerCrawler
 from plugins.applications.liberty import liberty_crawler
-from utils.crawler_exceptions import CrawlError
+from utils.namespace import run_as_another_namespace
+import json
+import utils.misc
+from requests.exceptions import ConnectionError
 
 logger = logging.getLogger('crawlutils')
 
@@ -16,7 +18,7 @@ class LibertyContainerCrawler(IContainerCrawler):
     def get_feature(self):
         return self.feature_key
 
-    def crawl(self, container_id=None, **kwargs):
+    def get_opt(self, kwargs):
         password = "password"
         user = "user"
 
@@ -26,32 +28,56 @@ class LibertyContainerCrawler(IContainerCrawler):
         if "user" in kwargs:
             user = kwargs["user"]
 
+        return password, user
+
+    def crawl(self, container_id=None, **kwargs):
+
+        password, user = self.get_opt(kwargs)
         c = dockercontainer.DockerContainer(container_id)
 
-        # check image name
-        if c.image_name.find(self.feature_key) == -1:
-            logger.error("%s is not %s container",
-                         c.image_name,
-                         self.feature_key)
-            raise CrawlError("%s does not have expected name for %s (name=%s)",
-                             container_id,
-                             self.feature_key,
-                             c.image_name)
+        port = None
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
 
-        # crawl all candidate ports
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
+
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
         for each_port in ports:
-                return liberty_crawler.retrieve_metrics(
-                    host=ip,
-                    port=each_port,
-                    user=user,
-                    password=password,
-                    feature_type=self.feature_type
-                )
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
 
-        raise CrawlError("%s has no accessible endpoint for %s",
-                         container_id,
-                         self.feature_key)
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        if not port:
+            return
+
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
+
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
+
+        try:
+            return liberty_crawler.retrieve_metrics(
+                host=ip,
+                port=port,
+                user=user,
+                password=password,
+                feature_type=self.feature_type)
+        except:
+            logger.info("liberty does not listen on port:%d", port)
+            raise ConnectionError("liberty does not listen on port:%d", port)

--- a/crawler/plugins/applications/nginx/nginx_container_crawler.py
+++ b/crawler/plugins/applications/nginx/nginx_container_crawler.py
@@ -1,9 +1,11 @@
 import logging
-
 import dockercontainer
 from icrawl_plugin import IContainerCrawler
 from plugins.applications.nginx import nginx_crawler
-from utils.crawler_exceptions import CrawlError
+from utils.namespace import run_as_another_namespace
+from requests.exceptions import ConnectionError
+import json
+import utils.misc
 
 logger = logging.getLogger('crawlutils')
 
@@ -11,6 +13,7 @@ logger = logging.getLogger('crawlutils')
 class NginxContainerCrawler(IContainerCrawler):
     feature_type = 'application'
     feature_key = 'nginx'
+    default_port = 80
 
     def get_feature(self):
         return self.feature_key
@@ -18,31 +21,49 @@ class NginxContainerCrawler(IContainerCrawler):
     def crawl(self, container_id=None, **kwargs):
         c = dockercontainer.DockerContainer(container_id)
 
-        # check image name
-        if c.image_name.find(self.feature_key) == -1:
-            logger.error("%s is not %s container",
-                         c.image_name,
-                         self.feature_key)
-            raise CrawlError("%s does not have expected name for %s (name=%s)",
-                             container_id,
-                             self.feature_key,
-                             c.image_name)
+        port = None
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
+
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
+
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
+        for each_port in ports:
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
+
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        if not port:
+            return
+
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
+
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
 
         # crawl all candidate ports
-        for port in ports:
-            try:
-                metrics = nginx_crawler.retrieve_metrics(ip, port)
-            except CrawlError:
-                logger.error("can't find metrics endpoint at http://%s:%s",
-                             ip,
-                             port)
-                continue
+        try:
+            metrics = nginx_crawler.retrieve_metrics(ip, port)
             return [(self.feature_key, metrics, self.feature_type)]
-
-        raise CrawlError("%s has no accessible endpoint for %s",
-                         container_id,
-                         self.feature_key)
+        except:
+            logger.error("can't find metrics endpoint at http://%s:%s",
+                         ip,
+                         port)
+            raise ConnectionError("can't find metrics endpoint"
+                                  "at http://%s:%s", ip, port)

--- a/crawler/plugins/applications/redis/redis_container_crawler.py
+++ b/crawler/plugins/applications/redis/redis_container_crawler.py
@@ -3,12 +3,16 @@ from plugins.applications.redis import feature
 import dockercontainer
 from requests.exceptions import ConnectionError
 import logging
+from utils.namespace import run_as_another_namespace
+import json
+import utils.misc
 
 
 logger = logging.getLogger('crawlutils')
 
 
 class RedisContainerCrawler(IContainerCrawler):
+
     '''
     Crawling app provided metrics for redis container on docker.
     Usually redis listens on port 6379.
@@ -18,40 +22,67 @@ class RedisContainerCrawler(IContainerCrawler):
     feature_key = "redis"
     default_port = 6379
 
+    def get_port(self, c):
+        port = None
+
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
+
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
+
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
+        for each_port in ports:
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
+
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        return port
+
     def get_feature(self):
         return self.feature_key
 
     def crawl(self, container_id=None, **kwargs):
 
-        import pip
-        pip.main(['install', 'redis'])
-        import redis
+        try:
+            import redis
+        except ImportError:
+            import pip
+            pip.main(['install', 'redis'])
+            import redis
 
         # only crawl redis container. Otherwise, quit.
         c = dockercontainer.DockerContainer(container_id)
-        if c.image_name.find(self.feature_key) == -1:
-            logger.debug("%s is not %s container" %
-                         (c.image_name, self.feature_key))
-            raise NameError("this is not target crawl container")
+        port = self.get_port(c)
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+        if not port:
+            return
 
-        # set default port number
-        if len(ports) == 0:
-            ports.append(self.default_port)
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
 
-        # query to all available ports
-        for port in ports:
-            client = redis.Redis(host=ip, port=port)
-            try:
-                metrics = client.info()
-            except ConnectionError:
-                logger.info("redis does not listen on port:%d", port)
-                continue
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
+
+        client = redis.Redis(host=ip, port=port)
+
+        try:
+            metrics = client.info()
             feature_attributes = feature.create_feature(metrics)
             return [(self.feature_key, feature_attributes, self.feature_type)]
-
-        # any ports are not available
-        raise ConnectionError("no listen ports")
+        except:
+            logger.info("redis does not listen on port:%d", port)
+            raise ConnectionError("no listen at %d", port)

--- a/crawler/plugins/applications/tomcat/tomcat_container_crawler.py
+++ b/crawler/plugins/applications/tomcat/tomcat_container_crawler.py
@@ -1,9 +1,11 @@
 import logging
-
 import dockercontainer
 from icrawl_plugin import IContainerCrawler
 from plugins.applications.tomcat import tomcat_crawler
-from utils.crawler_exceptions import CrawlError
+from utils.namespace import run_as_another_namespace
+import json
+import utils.misc
+from requests.exceptions import ConnectionError
 
 logger = logging.getLogger('crawlutils')
 
@@ -16,7 +18,7 @@ class TomcatContainerCrawler(IContainerCrawler):
     def get_feature(self):
         return self.feature_key
 
-    def crawl(self, container_id=None, **kwargs):
+    def get_opt(self, kwargs):
         password = "password"
         user = "tomcat"
 
@@ -26,32 +28,58 @@ class TomcatContainerCrawler(IContainerCrawler):
         if "user" in kwargs:
             user = kwargs["user"]
 
+        return password, user
+
+    def crawl(self, container_id=None, **kwargs):
+
+        password, user = self.get_opt(kwargs)
         c = dockercontainer.DockerContainer(container_id)
 
-        # check image name
-        if c.image_name.find(self.feature_key) == -1:
-            logger.error("%s is not %s container",
-                         c.image_name,
-                         self.feature_key)
-            raise CrawlError("%s does not have expected name for %s (name=%s)",
-                             container_id,
-                             self.feature_key,
-                             c.image_name)
+        port = None
 
-        # extract IP and Port information
-        ip = c.get_container_ip()
-        ports = c.get_container_ports()
+        if "annotation.io.kubernetes.container.ports" in\
+                c.inspect['Config']['Labels']:
+
+            ports = c.inspect['Config']['Labels'][
+                'annotation.io.kubernetes.container.ports']
+
+            ports = json.loads(ports)
+
+        else:
+            ports = c.get_container_ports()
+
+        for each_port in ports:
+            tmp_port = None
+            if "containerPort" in each_port:
+                tmp_port = int(each_port['containerPort'])
+            else:
+                tmp_port = int(each_port)
+
+            if tmp_port == self.default_port:
+                port = tmp_port
+
+        if not port:
+            return
+
+        state = c.inspect['State']
+        pid = str(state['Pid'])
+        ips = run_as_another_namespace(
+            pid, ['net'], utils.misc.get_host_ip4_addresses)
+
+        for each_ip in ips:
+            if each_ip != "127.0.0.1":
+                ip = each_ip
+                break
 
         # crawl all candidate ports
-        for each_port in ports:
-                return tomcat_crawler.retrieve_metrics(
-                    host=ip,
-                    port=each_port,
-                    user=user,
-                    password=password,
-                    feature_type=self.feature_type
-                )
-
-        raise CrawlError("%s has no accessible endpoint for %s",
-                         container_id,
-                         self.feature_key)
+        try:
+            return tomcat_crawler.retrieve_metrics(
+                host=ip,
+                port=port,
+                user=user,
+                password=password,
+                feature_type=self.feature_type)
+        except:
+            raise ConnectionError("%s has no accessible endpoint for %s",
+                                  container_id,
+                                  self.feature_key)


### PR DESCRIPTION
This PR adds a function to get ip address in K8S environment for metrics crawler.
The detail information about metrics crawler is described at issue #196

IP address is not assigned to each docker and it is not included in docker inspect information (`c.get_container_ip()`) in k8s. So we pass IP address to the crawler by env variable (`KUBE_POD_INFO`) .

Signed-off-by: Hitomi Takahashi <hitomi@jp.ibm.com>