### PR TITLE
Dlaas metric metadata changes

### DIFF
--- a/tests/unit/test_gpu_plugin.py
+++ b/tests/unit/test_gpu_plugin.py
@@ -14,11 +14,13 @@ class GPUPluginTests(unittest.TestCase):
         pass
 
     @mock.patch(
+        'plugins.systems.gpu_host_crawler.get_host_ipaddr',
+        #'plugins.systems.gpu_host_crawler.utils.misc.get_host_ipaddr',
+        #'utils.misc.get_host_ipaddr',
+        side_effect=lambda: "127.0.0.1")
+    @mock.patch(
         'plugins.systems.gpu_host_crawler.GPUHostCrawler._load_nvidia_lib',
         side_effect=lambda: 1)
-    @mock.patch(
-        'plugins.systems.gpu_host_crawler.utils.misc.get_host_ipaddr',
-        side_effect=lambda: "127.0.0.1")
     def test_os_gpu_host_crawler_plugin(self, *args):
         fc = GPUHostCrawler()
         for gpu_metrics in fc.crawl():

--- a/tests/unit/test_gpu_plugin.py
+++ b/tests/unit/test_gpu_plugin.py
@@ -5,7 +5,6 @@ sys.path.append('tests/unit/')
 sys.modules['pynvml'] = __import__('mock_pynvml')
 from plugins.systems.gpu_host_crawler import GPUHostCrawler
 
-
 class GPUPluginTests(unittest.TestCase):
 
     def setUp(self):
@@ -17,16 +16,17 @@ class GPUPluginTests(unittest.TestCase):
     @mock.patch(
         'plugins.systems.gpu_host_crawler.GPUHostCrawler._load_nvidia_lib',
         side_effect=lambda: 1)
+    @mock.patch('utils.misc.get_host_ipaddr',side_effect=lambda:"127.0.0.1")
     def test_os_gpu_host_crawler_plugin(self, *args):
         fc = GPUHostCrawler()
         for gpu_metrics in fc.crawl():
             print gpu_metrics
             assert gpu_metrics == (
-                'gpu0.containerid:NA',
+                '127/0/0/1.gpu0.NA',
                 {
                     "memory": {"total": 12205, "used": 0, "free": 12205},
                     "temperature": 31,
                     "power": {"draw": 27, "limit": 149},
                     "utilization": {"gpu": 0, "memory": 0}
                 },
-                'gpu')
+                'gpu')            

--- a/tests/unit/test_gpu_plugin.py
+++ b/tests/unit/test_gpu_plugin.py
@@ -16,7 +16,8 @@ class GPUPluginTests(unittest.TestCase):
     @mock.patch(
         'plugins.systems.gpu_host_crawler.GPUHostCrawler._load_nvidia_lib',
         side_effect=lambda: 1)
-    @mock.patch('utils.misc.get_host_ipaddr',side_effect=lambda:"127.0.0.1")
+    @mock.patch('plugins.systems.gpu_host_crawler.utils.misc.get_host_ipaddr',
+            side_effect=lambda:"127.0.0.1")
     def test_os_gpu_host_crawler_plugin(self, *args):
         fc = GPUHostCrawler()
         for gpu_metrics in fc.crawl():

--- a/tests/unit/test_gpu_plugin.py
+++ b/tests/unit/test_gpu_plugin.py
@@ -16,8 +16,9 @@ class GPUPluginTests(unittest.TestCase):
     @mock.patch(
         'plugins.systems.gpu_host_crawler.GPUHostCrawler._load_nvidia_lib',
         side_effect=lambda: 1)
-    @mock.patch('plugins.systems.gpu_host_crawler.utils.misc.get_host_ipaddr',
-            side_effect=lambda:"127.0.0.1")
+    @mock.patch(
+        'plugins.systems.gpu_host_crawler.utils.misc.get_host_ipaddr',
+        side_effect=lambda: "127.0.0.1")
     def test_os_gpu_host_crawler_plugin(self, *args):
         fc = GPUHostCrawler()
         for gpu_metrics in fc.crawl():


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

Changes included:

1. Host Name is being collected in the GPU plugin itself (so that it can be formatted)
2. Metric metadata is changed to include only k8s namespace and training-id or pod-name
