### PR TITLE
Dlaas metric metadata changes

### DIFF
--- a/crawler/plugins/systems/gpu_host_crawler.py
+++ b/crawler/plugins/systems/gpu_host_crawler.py
@@ -65,13 +65,14 @@ class GPUHostCrawler(IHostCrawler):
         for inspect in self.inspect_arr:
             state = inspect['State']
             cont_pid = int(state['Pid'])
+            cont_name = inspect['Name']
             cont_child_pids = self._get_children_pids(cont_pid)
             if pid in cont_child_pids:
                 labels = inspect['Config']['Labels']
-                pod_ns = labels.get('io.kubernetes.pod.namespace', 'NA')
-                pod_name = labels.get('io.kubernetes.pod.name', 'NA')
-                training_id = labels.get('training_id', pod_name)
-                name = "{}.{}".format(pod_ns, training_id)
+                namespace = labels.get('io.kubernetes.pod.namespace', 'NA')
+                pod_name = labels.get('io.kubernetes.pod.name', cont_name)
+                cont_idx = labels.get('training_id', pod_name)
+                name = "{}.{}".format(namespace, cont_idx)
                 return name
         return 'NA'
 

--- a/tests/unit/test_gpu_plugin.py
+++ b/tests/unit/test_gpu_plugin.py
@@ -5,7 +5,6 @@ sys.path.append('tests/unit/')
 sys.modules['pynvml'] = __import__('mock_pynvml')
 from plugins.systems.gpu_host_crawler import GPUHostCrawler
 
-
 class GPUPluginTests(unittest.TestCase):
 
     def setUp(self):
@@ -15,6 +14,9 @@ class GPUPluginTests(unittest.TestCase):
         pass
 
     @mock.patch(
+        'plugins.systems.gpu_host_crawler.get_host_ipaddr',
+        side_effect=lambda: "127.0.0.1")
+    @mock.patch(
         'plugins.systems.gpu_host_crawler.GPUHostCrawler._load_nvidia_lib',
         side_effect=lambda: 1)
     def test_os_gpu_host_crawler_plugin(self, *args):
@@ -22,11 +24,11 @@ class GPUPluginTests(unittest.TestCase):
         for gpu_metrics in fc.crawl():
             print gpu_metrics
             assert gpu_metrics == (
-                'gpu0.containerid:NA',
+                '127/0/0/1.gpu0.NA',
                 {
                     "memory": {"total": 12205, "used": 0, "free": 12205},
                     "temperature": 31,
                     "power": {"draw": 27, "limit": 149},
                     "utilization": {"gpu": 0, "memory": 0}
                 },
-                'gpu')
+                'gpu')            


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

Changes include:
1. Remove "containerid" string from metric name
2. Add only k8s-namespace and training-id or pod-name in the metric name

