### PR TITLE
updates namespace param based on source_type

### DIFF
--- a/crawler/crawler.conf
+++ b/crawler/crawler.conf
@@ -79,3 +79,4 @@
     access_group_filepath = /etc/sas-secrets/access_group
     cloudoe_filepath = /etc/sas-secrets/cloudoe
     ssl_verification = False
+    emit_interval_filepath = /etc/sas-secrets/emit_interval

--- a/crawler/plugins/emitters/sas_emitter.py
+++ b/crawler/plugins/emitters/sas_emitter.py
@@ -39,6 +39,18 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
         self.access_group_filepath = kwargs.get("access_group_filepath", "")
         self.cloudoe_filepath = kwargs.get("cloudoe_filepath", "")
         self.ssl_verification = kwargs.get("ssl_verification", "")
+        self.emit_interval_fpath = kwargs.get("emit_interval_filepath", "")
+        # set emit interval
+        if os.path.exists(self.emit_interval_fpath):
+            try:
+                with open(self.emit_interval_fpath) as fp:
+                    interval = fp.read().rstrip('\n')
+                interval_time = int(interval)
+                self.emit_interval = interval_time
+            except (ValueError, IOError):
+                self.emit_interval = 0
+        else:
+            self.emit_interval = 0
 
         iostream = self.format(frame)
         if compress:
@@ -58,6 +70,7 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
     Current model of secret deployment in k8s is through mounting
     'secret' inside crawler container.
     '''
+
     def get_sas_tokens(self):
         assert(os.path.exists(self.token_filepath))
         assert(os.path.exists(self.access_group_filepath))
@@ -77,6 +90,35 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
 
         return(token, cloudoe, access_group)
 
+    def gen_params(self, namespace='', features='', timestamp='',
+                   access_group='', source_type=''):
+        params = {}
+
+        # reformat namespace and access_group for icp env
+        parsed_namespace = namespace.split("/")
+        if len(parsed_namespace) >= 2 and parsed_namespace[0] == "icp":
+            # set an adequate k8s namespace
+            access_group = parsed_namespace[1]
+            # remove "icp/" string from namespace
+            namespace = namespace[4:]
+            assert namespace[0] != "/"
+        logger.info("emit frame (namespace=%s)", namespace)
+
+        params.update({'namespace': namespace})
+        params.update({'access_group': access_group})
+        params.update({'features': features})
+        params.update({'timestamp': timestamp})
+
+        # load source_type if env exists
+        # live crawler should be set it as 'container' and
+        # reg crawler should be set it as 'image'
+        if 'SOURCE_TYPE' in os.environ:
+            source_type = os.environ['SOURCE_TYPE']
+            assert source_type == 'image' or source_type == 'container'
+        params.update({'source_type': source_type})
+
+        return params
+
     '''
     SAS requires following crawl metadata about entity
     being crawled.
@@ -87,6 +129,7 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
     This function parses the crawled metadata feature and
     gets these information.
     '''
+
     def __parse_crawl_metadata(self, content=''):
         metadata_str = content.split('\n')[0].split()[2]
         metadata_json = json.loads(metadata_str)
@@ -105,27 +148,23 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
         headers.update({'Cloud-OE-ID': cloudoe})
         headers.update({'X-Auth-Token': token})
 
-        params = {}
-        params.update({'access_group': access_group})
-        params.update({'namespace': namespace})
-        params.update({'features': features})
-        params.update({'timestamp': timestamp})
-
-        # load source_type from env variables
-        # if not set, it uses system_type as a default value
-        # live crawler should be set it as 'container' and
-        # reg crawler should be set it as 'image'
-        if 'SOURCE_TYPE' in os.environ:
-            source_type = os.environ['SOURCE_TYPE']
-            params.update({'source_type': source_type})
-        else:
-            params.update({'source_type': system_type})
+        params = self.gen_params(namespace=namespace, features=features,
+                                 timestamp=timestamp, source_type=system_type,
+                                 access_group=access_group)
 
         self.url = self.url.replace('sas:', 'https:')
 
         verify = True
         if self.ssl_verification == "False":
             verify = False
+            from requests.packages.urllib3.exceptions \
+                import InsecureRequestWarning
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+        # set interval to avoid burst emit
+        if int(self.emit_interval) > 0:
+            logger.debug("wait %s sec...", self.emit_interval)
+            time.sleep(int(self.emit_interval))
 
         for attempt in range(self.max_retries):
             try:

--- a/crawler/plugins/environments/icp_environment.plugin
+++ b/crawler/plugins/environments/icp_environment.plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = ICp Environment
+Module = icp_environment
+
+[Documentation]
+Author = IBM
+Version = 0.1
+Description = ICp environment

--- a/crawler/plugins/environments/icp_environment.py
+++ b/crawler/plugins/environments/icp_environment.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+import logging
+import copy
+import re
+
+from runtime_environment import IRuntimeEnvironment
+from utils.dockerutils import exec_dockerinspect
+
+logger = logging.getLogger('crawlutils')
+
+META_CONFIG = 'Config'
+META_LABELS = 'Labels'
+META_UUID = 'Id'
+META_HOSTNAME = 'Hostname'
+META_REPO = 'RepoTag'
+
+K8S_NS_LABEL = "io.kubernetes.pod.namespace"
+K8S_POD_LABEL = "io.kubernetes.pod.name"
+K8S_CONTAINER_NAME_LABEL = "io.kubernetes.container.name"
+
+CRAWLER_CONT_NAMESPACE_FORMAT = "icp/{K8S_NS}/{K8S_POD}/{K8S_CONT_ID}"
+CRAWLER_IMAGE_NAMESPACE_FORMAT = "icp/{IMAGE_NAME}"
+
+regpod_pattern = re.compile("regpod-checking")
+
+
+class ICpEnvironment(IRuntimeEnvironment):
+    name = 'icp'
+
+    def get_environment_name(self):
+        return self.name
+
+    def get_container_namespace(self, long_id, options):
+        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        crawler_k8s_ns = ""
+        container_meta = exec_dockerinspect(long_id)
+        try:
+            labels = container_meta.get(META_CONFIG).get(META_LABELS)
+            if labels:
+                podname = labels.get(K8S_POD_LABEL)
+                # for reg crawler
+                if regpod_pattern.search(podname):
+                    # repotag format == "repository/k8s-ns/imagename:tag"
+                    repotag = container_meta.get(META_REPO)
+                    peaces = repotag.split("/")
+                    ns_image_tag = peaces[1] + "/" + peaces[2]
+                    crawler_k8s_ns = CRAWLER_IMAGE_NAMESPACE_FORMAT.format(
+                        IMAGE_NAME=ns_image_tag
+                    )
+                # for live crawler
+                else:
+                    crawler_k8s_ns = CRAWLER_CONT_NAMESPACE_FORMAT.format(
+                        K8S_NS=labels.get(K8S_NS_LABEL, ""),
+                        K8S_POD=labels.get(K8S_POD_LABEL, ""),
+                        K8S_CONT_ID=long_id
+                    )
+        except KeyError:
+            logger.error('Error retrieving container labels for: %s' %
+                         long_id)
+            pass
+
+        return crawler_k8s_ns
+
+    def get_container_log_file_list(self, long_id, options):
+        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        assert 'container_logs' in options
+        container_logs = copy.deepcopy(options['container_logs'])
+        for log in container_logs:
+            name = log['name']
+            if not os.path.isabs(name) or '..' in name:
+                container_logs.remove(log)
+                logger.warning(
+                    'User provided a log file path that is not absolute: %s' %
+                    name)
+        return container_logs
+
+    def get_container_log_prefix(self, long_id, options):
+        assert isinstance(long_id, str) or unicode, "long_id is not a string"
+        assert 'name' in options and 'host_namespace' in options
+        name = options['name']
+        name = (name if len(name) > 0 else long_id[:12])
+        name = (name[1:] if name[0] == '/' else name)
+        return options['host_namespace'] + '/' + name


### PR DESCRIPTION
This PR is a request from SAS service. 

Since SAS expects namespace format to be set as the following format,  I modified namespace format from original k8s environment namespace (i.e. `<k8s ns>/<pod name>/<deployment name>/<container long id>`) to the shorten ones. 

if `source_type == container`: 
`<k8s ns>/<pod name>/<container_id>` for live crawler
if `source_type == image`: 
`<k8s ns>/<image name>:<image tag>` for reg crawler


Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>