### PR TITLE
add bearer token in SAS header entry to support icp internal authz change

### DIFF
--- a/crawler/plugins/emitters/sas_emitter.py
+++ b/crawler/plugins/emitters/sas_emitter.py
@@ -147,6 +147,7 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
         headers = {'content-type': 'application/csv'}
         headers.update({'Cloud-OE-ID': cloudoe})
         headers.update({'X-Auth-Token': token})
+        headers.update({'Authorization': 'Bearer ' + token})
 
         params = self.gen_params(namespace=namespace, features=features,
                                  timestamp=timestamp, source_type=system_type,


### PR DESCRIPTION
Bearer token (header entry) is required for emitting frame to SAS, because the authorization logic in ICP changed recently.

Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>