### PR TITLE
set os_distro and os_version separately

### DIFF
--- a/crawler/utils/os_utils.py
+++ b/crawler/utils/os_utils.py
@@ -19,12 +19,8 @@ def crawl_os():
         os_kernel = 'unknown'
 
     result = osinfo.get_osinfo(mount_point='/')
-    if result:
-        os_distro = result['os']
-        os_version = result['version']
-    else:
-        os_distro = 'unknown'
-        os_version = 'unknown'
+    os_distro = result['os'] if 'os' in result else 'unknown'
+    os_version = result['version'] if 'version' in result else 'unknown'
 
     ips = utils.misc.get_host_ip4_addresses()
 
@@ -45,12 +41,8 @@ def crawl_os():
 
 def crawl_os_mountpoint(mountpoint='/'):
     result = osinfo.get_osinfo(mount_point=mountpoint)
-    if result:
-        os_distro = result['os']
-        os_version = result['version']
-    else:
-        os_distro = 'unknown'
-        os_version = 'unknown'
+    os_distro = result['os'] if 'os' in result else 'unknown'
+    os_version = result['version'] if 'version' in result else 'unknown'
 
     feature_key = 'linux'
     feature_attributes = OSFeature(  # boot time unknown for img


### PR DESCRIPTION
This PR contains a fix for the issue (#353). 

By setting `os_distro` and `os_version` independently, crawler can make os_feature even if `os_version` is missing. 

Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>