### PR TITLE
keep all repotags and use it icp environment

### DIFF
--- a/crawler/plugins/environments/icp_environment.py
+++ b/crawler/plugins/environments/icp_environment.py
@@ -15,7 +15,7 @@ META_CONFIG = 'Config'
 META_LABELS = 'Labels'
 META_UUID = 'Id'
 META_HOSTNAME = 'Hostname'
-META_REPO = 'RepoTag'
+META_REPOS = 'RepoTags'
 
 K8S_NS_LABEL = "io.kubernetes.pod.namespace"
 K8S_POD_LABEL = "io.kubernetes.pod.name"
@@ -43,8 +43,16 @@ class ICpEnvironment(IRuntimeEnvironment):
                 podname = labels.get(K8S_POD_LABEL)
                 # for reg crawler
                 if regpod_pattern.search(podname):
-                    # repotag format == "repository/k8s-ns/imagename:tag"
-                    repotag = container_meta.get(META_REPO)
+                    # expected repotag is "repository/k8s-ns/imagename:tag"
+                    repotags = container_meta.get(META_REPOS)
+                    repotag_format = ""
+                    for repotag in repotags:
+                        if len(repotag.split("/")) == 3:
+                            repotag_format = repotag.split("/")
+                            break
+                    # check format
+                    e_msg = "can not find proper repotag in this image"
+                    assert repotag_format != "", e_msg
                     peaces = repotag.split("/")
                     ns_image_tag = peaces[1] + "/" + peaces[2]
                     crawler_k8s_ns = CRAWLER_IMAGE_NAMESPACE_FORMAT.format(

--- a/crawler/utils/dockerutils.py
+++ b/crawler/utils/dockerutils.py
@@ -79,11 +79,14 @@ def exec_dockerinspect(long_id):
         raise DockerutilsException('Failed to exec dockerinspect')
 
     try:
+        repotags = client.inspect_image(inspect['Image'])['RepoTags']
         # get the first RepoTag
-        inspect['RepoTag'] = client.inspect_image(
-            inspect['Image'])['RepoTags'][0]
+        inspect['RepoTag'] = repotags[0]
+        # keep multiple RepoTags
+        inspect['RepoTags'] = repotags
     except (docker.errors.DockerException, KeyError, IndexError):
         inspect['RepoTag'] = ''
+        inspect['RepoTags'] = ''
 
     return inspect
 

--- a/tests/unit/test_dockerutils.py
+++ b/tests/unit/test_dockerutils.py
@@ -62,7 +62,7 @@ class MockedClient():
         }
 
     def inspect_image(self, image_id):
-        return {'RepoTags': 'registry/abc/def:latest'}
+        return {'RepoTags': ['registry/abc/def:latest', 'debian:latest']}
 
     def history(self, image_id):
         return [{'History': 'xxx'}]
@@ -100,7 +100,8 @@ class DockerUtilsTests(unittest.TestCase):
 
         assert c == {'Name': '/pensive_rosalind',
                      'Created': epoch_seconds,
-                     'RepoTag': 'r',
+                     'RepoTag': 'registry/abc/def:latest',
+                     'RepoTags': ['registry/abc/def:latest', 'debian:latest'],
                      'State': {'Status': 'running',
                                'Running': True,
                                'Pid': '11186'},
@@ -147,7 +148,8 @@ class DockerUtilsTests(unittest.TestCase):
 
         assert i == {'Name': '/pensive_rosalind',
                      'Created': epoch_seconds,
-                     'RepoTag': 'r',
+                     'RepoTag': 'registry/abc/def:latest',
+                     'RepoTags': ['registry/abc/def:latest', 'debian:latest'],
                      'State': {'Status': 'running',
                                'Running': True,
                                'Pid': '11186'},


### PR DESCRIPTION
This PR resolves an issue related to docker image repotag (#355). 

Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>