### PR TITLE
disabling docker events

### DIFF
--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -85,8 +85,7 @@ def poll_docker_containers(timeout, user_list=None, host_namespace=''):
     try:
         # We are currently throttling docker events
         # so instead of polling we will just sleep for timeout  interval
-        time.sleep(timeout)
-        
+        time.sleep(timeout) 
         # cEvent = poll_container_create_events(timeout)
 
         # if not cEvent:

--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import shutil
+import time
 
 from requests.exceptions import HTTPError
 
@@ -83,14 +84,17 @@ def poll_docker_containers(timeout, user_list=None, host_namespace=''):
         return None
 
     try:
-        cEvent = poll_container_create_events(timeout)
+        # We are currently throttling docker events 
+        # so instead of polling we will just sleep for timeout  interval
+        time.sleep(timeout)
+        #cEvent = poll_container_create_events(timeout)
 
-        if not cEvent:
-            return None
-        c = DockerContainer(cEvent.get_containerid(), inspect=None,
-                            host_namespace=host_namespace)
-        if c.namespace:
-            return c
+        #if not cEvent:
+        #    return None
+        #c = DockerContainer(cEvent.get_containerid(), inspect=None,
+        #                    host_namespace=host_namespace)
+        #if c.namespace:
+        #    return c
     except ContainerInvalidEnvironment as e:
         logger.exception(e)
 

--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -22,8 +22,7 @@ from utils.crawler_exceptions import (ContainerInvalidEnvironment,
 from utils.dockerutils import (exec_dockerps,
                                get_docker_container_json_logs_path,
                                get_docker_container_rootfs_path,
-                               exec_dockerinspect,
-                               poll_container_create_events)
+                               exec_dockerinspect)
 
 try:
     basestring        # Python 2
@@ -84,16 +83,17 @@ def poll_docker_containers(timeout, user_list=None, host_namespace=''):
         return None
 
     try:
-        # We are currently throttling docker events 
+        # We are currently throttling docker events
         # so instead of polling we will just sleep for timeout  interval
         time.sleep(timeout)
-        #cEvent = poll_container_create_events(timeout)
+        
+        # cEvent = poll_container_create_events(timeout)
 
-        #if not cEvent:
+        # if not cEvent:
         #    return None
-        #c = DockerContainer(cEvent.get_containerid(), inspect=None,
+        # c = DockerContainer(cEvent.get_containerid(), inspect=None,
         #                    host_namespace=host_namespace)
-        #if c.namespace:
+        # if c.namespace:
         #    return c
     except ContainerInvalidEnvironment as e:
         logger.exception(e)

--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -85,7 +85,7 @@ def poll_docker_containers(timeout, user_list=None, host_namespace=''):
     try:
         # We are currently throttling docker events
         # so instead of polling we will just sleep for timeout  interval
-        time.sleep(timeout) 
+        time.sleep(timeout)
         # cEvent = poll_container_create_events(timeout)
 
         # if not cEvent:

--- a/tests/functional/test_functional_dockerevents.py
+++ b/tests/functional/test_functional_dockerevents.py
@@ -71,7 +71,7 @@ class CrawlerDockerEventTests(unittest.TestCase):
     In this case, crawler would miss the create event, but it should be able to
     discover already running containers and snapshot them
     '''
-    def testCrawlContainer0(self):
+    def _noexec_testCrawlContainer0(self):
         env = os.environ.copy()
         mypath = os.path.dirname(os.path.realpath(__file__))
         os.makedirs(self.tempd + '/out')
@@ -114,7 +114,7 @@ class CrawlerDockerEventTests(unittest.TestCase):
     crawler should get intrupptted and start snapshotting container immediately.
 
     '''
-    def testCrawlContainer1(self):
+    def _noexec_testCrawlContainer1(self):
         env = os.environ.copy()
         mypath = os.path.dirname(os.path.realpath(__file__))
         os.makedirs(self.tempd + '/out')
@@ -169,7 +169,7 @@ class CrawlerDockerEventTests(unittest.TestCase):
     And then we will wait for crawler's next iteration to ensure, w/o docker event,
     crawler will timeout and snapshot container periodically
     '''
-    def testCrawlContainer2(self):
+    def _noexec_testCrawlContainer2(self):
         env = os.environ.copy()
         mypath = os.path.dirname(os.path.realpath(__file__))
         os.makedirs(self.tempd + '/out')


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

This change is to disable docker event support in crawler currently.

There were couple of concerns regarding docker-event behavior for live containers in k8s environment:

1. if some pod is restarted multiple times, or stuck in the crashloopback then crawler crawls them repeatedly and there is lot of redundancy in terms of space consumption at Kafka, execution by annotators and results in ES
2. Usage of sas-apis becomes difficult, since many redundant namespaces gets shown up in /get-namespaces APIs.

Going forward as suggested by @canturkisci : 
-----------
Step 2: Make Docker events as config option
Step 3: Explore options:
--- Option 1. Run only periodic crawler; Check “uptime” of containers and only scan those that are old enough
--- Option 2. Handle events at the wrapper and do similar kind of checks on whether to actually scan a container when an even comes