### PR TITLE
fix icp env plugin bug for crawling non-icp managed containers

### DIFF
--- a/crawler/plugins/environments/icp_environment.py
+++ b/crawler/plugins/environments/icp_environment.py
@@ -41,6 +41,9 @@ class ICpEnvironment(IRuntimeEnvironment):
             labels = container_meta.get(META_CONFIG).get(META_LABELS)
             if labels:
                 podname = labels.get(K8S_POD_LABEL)
+                if not podname:
+                    logger.warning("%s is not k8s managed Container" % long_id)
+                    return crawler_k8s_ns
                 # for reg crawler
                 if regpod_pattern.search(podname):
                     # expected repotag is "repository/k8s-ns/imagename:tag"


### PR DESCRIPTION
ICP env plugin failed if crawling non k8s managed container, because it did not check `podname` label existence. By this PR, crawler can raise `ContainerInvalidEnvironment` Exception for the container. 

Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>