### PR TITLE
fix icp env plugin to include containername again

### DIFF
--- a/crawler/plugins/emitters/sas_emitter.py
+++ b/crawler/plugins/emitters/sas_emitter.py
@@ -95,14 +95,10 @@ class SasEmitter(BaseHttpEmitter, IEmitter):
                    access_group='', source_type=''):
         params = {}
 
-        # reformat namespace and access_group for icp env
+        # extract access_group info from namespace
         parsed_namespace = namespace.split("/")
-        if len(parsed_namespace) >= 2 and parsed_namespace[0] == "icp":
-            # set an adequate k8s namespace
-            access_group = parsed_namespace[1]
-            # remove "icp/" string from namespace
-            namespace = namespace[4:]
-            assert namespace[0] != "/"
+        if len(parsed_namespace) > 1:
+            access_group = parsed_namespace[0]
 
         params.update({'namespace': namespace})
         params.update({'access_group': access_group})


### PR DESCRIPTION
This PR Includes `io.kubernetes.container.name` again in namespace on icp environment, that is the same as kubernetes env plugin. Also fixed redundant code in sas-emitter and icp-environment plugins. 

Signed-off-by: Tatsuhiro Chiba <chiba@jp.ibm.com>