### PR TITLE
Fixing cpu usage value in metric and cpu plugins

### DIFF
--- a/crawler/crawler.conf
+++ b/crawler/crawler.conf
@@ -8,6 +8,10 @@
 		
     [[ process_container ]]		
     get_mmap_files = False
+
+    [[ cpu_container ]]
+    # False for [0-100%]; True for [0-NCPU*100%] == docker stats type CPU usage
+    metric_type_absolute = True
 		
     [[ os_vm ]]		
 		

--- a/crawler/plugins/systems/cpu_container_crawler.py
+++ b/crawler/plugins/systems/cpu_container_crawler.py
@@ -38,6 +38,21 @@ class CpuContainerCrawler(IContainerCrawler):
         cache_key = container_long_id
         return self._cache_get_value(cache_key)
 
+    def _get_scaling_factor(self, container, per_cpu):
+        if per_cpu:
+            return 1.0
+
+        fd = open(container.get_cpu_cgroup_path('cpu.cfs_quota_us'), 'r')
+        quota = float(fd.read().strip())
+        fd.close()
+        if quota == -1:
+            return 1.0
+
+        fd = open(container.get_cpu_cgroup_path('cpu.cfs_period_us'), 'r')
+        period = float(fd.read().strip())
+        fd.close()
+        return float(quota / period)
+
     def get_feature(self):
         return 'cpu'
 
@@ -45,6 +60,8 @@ class CpuContainerCrawler(IContainerCrawler):
         logger.debug(
             'Crawling %s for container %s' %
             (self.get_feature(), container_id))
+
+        self.metric_type_absolute = kwargs.get('metric_type_absolute', 'False')
 
         container = DockerContainer(container_id)
 
@@ -60,7 +77,6 @@ class CpuContainerCrawler(IContainerCrawler):
                 cpu.steal,
                 100 - int(cpu.idle),
             )
-
         if per_cpu:
             stat_file_name = 'cpuacct.usage_percpu'
         else:
@@ -109,10 +125,15 @@ class CpuContainerCrawler(IContainerCrawler):
 
             # Interval is never 0 because of step 0 (forcing a sleep)
 
-            usage_percent = usage_secs / interval * 100.0
-            if usage_percent > 100.0:
-                usage_percent = 100.0
-            idle = 100.0 - usage_percent
+            # for fractional / multicore container
+            scaling_factor = self._get_scaling_factor(container, per_cpu)
+            if self.metric_type_absolute == 'True':
+                usage_percent = usage_secs / interval * 100.0
+                idle = (scaling_factor * interval - usage_secs) / \
+                    interval * 100.0
+            else:
+                usage_percent = usage_secs / scaling_factor / interval * 100.0
+                idle = 100 - usage_percent
 
             # Approximation 1
 

--- a/crawler/utils/metric_utils.py
+++ b/crawler/utils/metric_utils.py
@@ -6,7 +6,7 @@ from utils.features import MetricFeature
 def _crawl_metrics_cpu_percent(process):
     cpu_percent = (
         process.get_cpu_percent(
-            interval=0) if hasattr(
+            interval=0.1) if hasattr(
             process.get_cpu_percent,
             '__call__') else process.cpu_percent)
     return cpu_percent

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1535,6 +1535,8 @@ class PluginTests(unittest.TestCase):
                 50,
                 60,
                 70)])
+    @mock.patch('plugins.systems.cpu_container_crawler.CpuContainerCrawler._get_scaling_factor',
+                side_effect=lambda a,b: 1.0)
     @mock.patch('plugins.systems.cpu_container_crawler.time.sleep')
     @mock.patch('plugins.systems.cpu_container_crawler.open',
                 side_effect=mocked_cpu_cgroup_open)


### PR DESCRIPTION
- Fixes metric plugin that showed 0 CPU usage for procs
- Added support for fractional / multicore conts 
```
metadata    "metadata"    {"container_long_id":"478f686153d5dd6a35d672af9c73e9ae62cbfe1ae1b85c471a7e715757f0bb66","features":"cpu,metric","emit_shortname":"478f686153d5","timestamp":"2018-07-30T11:53:22-0400","docker_image_short_name":"ubuntu:latest","namespace":"192.168.122.165/stupefied_archimedes","docker_image_registry":"","owner_namespace":"","docker_image_tag":"latest","container_short_id":"478f686153d5","system_type":"container","container_name":"stupefied_archimedes","container_image":"sha256:113a43faa1382a7404681f1b9af2f0d70b182c569aab71db497e33fa59ed87e6","docker_image_long_name":"ubuntu:latest","uuid":"451fed97-c2b5-4c56-8749-fa19e32c68dd"}
metric    "tail/1"    {"cpupct":0.0,"mempct":0.01,"pname":"tail","pid":1,"read":0,"rss":782336,"status":"sleeping","user":"root","vms":4677632,"write":0}
metric    "bash/8"    {"cpupct":0.0,"mempct":0.06,"pname":"bash","pid":8,"read":16384,"rss":3465216,"status":"sleeping","user":"root","vms":18952192,"write":71254016}
metric    "stress/315"    {"cpupct":0.0,"mempct":0.02,"pname":"stress","pid":315,"read":0,"rss":1101824,"status":"sleeping","user":"root","vms":8437760,"write":0}
metric    "stress/316"    {"cpupct":99.3,"mempct":0.0,"pname":"stress","pid":316,"read":0,"rss":98304,"status":"running","user":"root","vms":8437760,"write":0}
metric    "stress/317"    {"cpupct":99.8,"mempct":0.0,"pname":"stress","pid":317,"read":0,"rss":98304,"status":"running","user":"root","vms":8437760,"write":0}
metric    "python2.7/322"    {"cpupct":0.0,"mempct":0.48,"pname":"python2.7","pid":322,"read":0,"rss":30203904,"status":"running","user":"root","vms":103677952,"write":0}
cpu    "cpu-0"    {"cpu_idle":0.0,"cpu_nice":0.0,"cpu_user":99.4028230184582,"cpu_wait":0.0,"cpu_system":0.5971769815418024,"cpu_interrupt":0.0,"cpu_steal":0.0,"cpu_util":100.0}
```