### PR TITLE
Adding temp k8 cgroup support

### DIFF
--- a/crawler/dockercontainer.py
+++ b/crawler/dockercontainer.py
@@ -99,6 +99,7 @@ def poll_docker_containers(timeout, user_list=None, host_namespace=''):
 
 
 class LogFileLink():
+
     """
     If `host_log_dir is not None`, then we should prefix `dest` with
     `host_log_dir`.
@@ -299,14 +300,30 @@ class DockerContainer(Container):
 
         raise ContainerWithoutCgroups('Can not find the cgroup dir')
 
+    def resolve_cont_cgroup_path_docker_k8(self, cgroup_dir, node):
+        docker_cgroup_path = os.path.join(cgroup_dir, 'docker')
+        if os.path.exists(docker_cgroup_path):
+            return os.path.join(docker_cgroup_path, self.long_id, node)
+
+        # k8 specific hack for now until k8 becomes first class citizen
+        # should use k8 python client to be cleaner
+        k8_cgroup_path = os.path.join(cgroup_dir, 'kubepods')
+        if not os.path.exists(k8_cgroup_path):
+            raise ContainerWithoutCgroups('Can not find the cgroup dir')
+
+        for (root_dirpath, dirs, files) in os.walk(k8_cgroup_path):
+            if self.long_id in dirs:
+                pod_cgroup_path = root_dirpath
+                return os.path.join(pod_cgroup_path, self.long_id, node)
+
     def get_memory_cgroup_path(self, node='memory.stat'):
-        return os.path.join(self._get_cgroup_dir(['memory']), 'docker',
-                            self.long_id, node)
+        cgroup_dir = self._get_cgroup_dir(['memory'])
+        return self.resolve_cont_cgroup_path_docker_k8(cgroup_dir, node)
 
     def get_cpu_cgroup_path(self, node='cpuacct.usage'):
         # In kernels 4.x, the node is actually called 'cpu,cpuacct'
         cgroup_dir = self._get_cgroup_dir(['cpuacct', 'cpu,cpuacct'])
-        return os.path.join(cgroup_dir, 'docker', self.long_id, node)
+        return self.resolve_cont_cgroup_path_docker_k8(cgroup_dir, node)
 
     def __str__(self):
         return str(self.__dict__)

--- a/tests/unit/test_dockercontainer.py
+++ b/tests/unit/test_dockercontainer.py
@@ -459,8 +459,12 @@ class DockerDockerContainerTests(unittest.TestCase):
                 side_effect=mocked_get_rootfs)
     @mock.patch('dockercontainer.os.path.ismount',
                 side_effect=lambda x: True if x == '/cgroup/memory' else False)
+    @mock.patch('dockercontainer.os.path.exists',
+                side_effect=lambda x:
+                True if x == '/cgroup/memory/docker' else False)
     def test_memory_cgroup(
             self,
+            mocked_exists,
             mocked_ismount,
             mock_get_rootfs,
             mock_inspect,
@@ -481,8 +485,12 @@ class DockerDockerContainerTests(unittest.TestCase):
     @mock.patch('dockercontainer.os.path.ismount',
                 side_effect=lambda x:
                 True if x == '/cgroup/cpuacct' or '/cgroup/cpu,cpuacct' else False)
+    @mock.patch('dockercontainer.os.path.exists',
+                side_effect=lambda x:
+                True if x == '/cgroup/cpuacct/docker' else False)
     def test_cpu_cgroup(
             self,
+            mocked_exists,
             mocked_ismount,
             mock_get_rootfs,
             mock_inspect,


### PR DESCRIPTION
example output from tatsuhiro's k8 env:
```
metadata    "metadata"    {"container_long_id":"b2681c6453eae403ecc8b4ec7bb65fe4dd5688430fec1a7c0482cbbfa57a5ee1","features":"os,memory,cpu","emit_shortname":"b2681c6453ea","timestamp":"2018-07-30T21:58:23+0000","docker_image_short_name":"live-crawler-x86:app","namespace":"10.1.72.201/k8s_live-crawler_vulnerability-advisor-live-crawler-tvqx5_kube-system_a150501e-7065-11e8-a17f-06b9009393d7_2","docker_image_registry":"cloudviz","owner_namespace":"","docker_image_tag":"app","container_short_id":"b2681c6453ea","system_type":"container","container_name":"k8s_live-crawler_vulnerability-advisor-live-crawler-tvqx5_kube-system_a150501e-7065-11e8-a17f-06b9009393d7_2","container_image":"sha256:df9a9e301bed12af51923161dc35e625cd24f883901651a7386b1a919ea2e266","docker_image_long_name":"cloudviz/live-crawler-x86:app","uuid":"af576311-43a9-4a70-9d4a-29705ff673b1"}
os    "linux"    {"boottime":1532505445.0,"uptime":482458.0,"ipaddr":["127.0.0.1","10.1.72.201"],"os":"debian","os_version":"9","os_kernel":"Linux-4.4.0-130-generic-x86_64-with-debian-9.4","architecture":"x86_64"}
memory    "memory"    {"memory_used":1640501248,"memory_buffered":448081920,"memory_cached":475004928,"memory_free":3303723008,"memory_util_percentage":33.1801545208875}
cpu    "cpu-0"    {"cpu_idle":98.654661,"cpu_nice":0.0,"cpu_user":1.0819120854489725,"cpu_wait":0.0,"cpu_system":0.26342691455102757,"cpu_interrupt":0.0,"cpu_steal":0.0,"cpu_util":1.345339}
```