### PR TITLE
fix security alert for pip pkg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ morph==0.1.2
 fluent-logger==0.4.6
 requests_unixsocket==0.1.5
 minio==4.0.18
-urllib3==1.22
+urllib3==1.24.2


### PR DESCRIPTION
##Vulnerabilities:
=========
```
CVE-2019-11324 More information

high severity
Vulnerable versions: < 1.24.2
Patched version: 1.24.2
The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.
CVE-2018-20060 More information

high severity
Vulnerable versions: < 1.23
Patched version: 1.23
urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.
```

##Remediation
=========
Upgrade urllib3 to version 1.24.2 or later. For example:

urllib3>=1.24.2