### PR TITLE
updating docker repo in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ before_install:
     - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
     - sudo apt-key update
     - sudo apt-get update
-    - sudo apt-get upgrade -y
+    - sudo apt-get upgrade
+    #- sudo apt-get upgrade -y --allow-unauthenticated
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
     #- sudo apt-get upgrade
     #- sudo apt-get upgrade -y --allow-unauthenticated
     #- sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
-    - sudo apt-get install docker-ce=${DOCKER_VERSION}
+    - sudo apt-get install docker-ce
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings
     # sudo -H pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
     - sudo apt-get update
-    - sufo apt-get upgrade -y
+    - sudo apt-get upgrade -y
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
     - ./.validateDCO
     - sudo apt-key update
     - sudo apt-get install apt-transport-https  ca-certificates curl gnupg-agent software-properties-common 
-    - curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     - sudo apt-key fingerprint 0EBFCD88
-    - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/debian  $(lsb_release -cs) stable"
+    - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
     - sudo apt-get update
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,8 @@ before_install:
     - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
-    #- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
-    #- sudo apt-key update
     - sudo apt-get update
-    #- sudo apt-get install libc6
-    #- sudo apt-get upgrade
-    #- sudo apt-get upgrade -y --allow-unauthenticated
-    #- sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
-    - sudo apt-get install docker-ce
+    - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings
     # sudo -H pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
     - sudo apt-get update
+    - sufo apt-get upgrade -y
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
     - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
+    - sudo apt-key update
     - sudo apt-get update
     - sudo apt-get upgrade -y
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,11 @@ before_install:
     - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     - sudo apt-key fingerprint 0EBFCD88
     - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable"
-    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
-    - sudo apt-key update
+    #- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+    #- sudo apt-key update
     - sudo apt-get update
-    - sudo apt-get upgrade
+    - sudo apt-get install libc6
+    #- sudo apt-get upgrade
     #- sudo apt-get upgrade -y --allow-unauthenticated
     - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ services:
 
 env:
   matrix:
-    - DOCKER_VERSION=1.7.1-0~trusty
-    - DOCKER_VERSION=1.9.1-0~trusty
-    - DOCKER_VERSION=1.10.1-0~trusty
-    - DOCKER_VERSION=1.11.1-0~trusty
     - DOCKER_VERSION=17.03.0~ce-0~ubuntu-trusty
 
 python:
@@ -19,11 +15,13 @@ python:
 
 before_install:
     - ./.validateDCO
-    - sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list'
-    - sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    - sudo apt-get update
     - sudo apt-key update
-    - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=${DOCKER_VERSION}
+    - sudo apt-get install apt-transport-https  ca-certificates curl gnupg-agent software-properties-common 
+    - curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+    - sudo apt-key fingerprint 0EBFCD88
+    - sudo add-apt-repository  "deb [arch=amd64] https://download.docker.com/linux/debian  $(lsb_release -cs) stable"
+    - sudo apt-get update
+    - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings
     # sudo -H pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,11 @@ before_install:
     #- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
     #- sudo apt-key update
     - sudo apt-get update
-    - sudo apt-get install libc6
+    #- sudo apt-get install libc6
     #- sudo apt-get upgrade
     #- sudo apt-get upgrade -y --allow-unauthenticated
-    - sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
+    #- sudo apt-get -qqy --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-ce=${DOCKER_VERSION}
+    - sudo apt-get install docker-ce=${DOCKER_VERSION}
     - docker -v
     # might as well upgrade pip to support TLS and get rid of the warnings
     # sudo -H pip install --upgrade pip


### PR DESCRIPTION
Trying to update test environment setup but travis still failing with error: `/usr/bin/python: relocation error: /lib/x86_64-linux-gnu/libnss_compat.so.2: symbol __nss_database_lookup2, version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference`